### PR TITLE
fix: increase max number of checkpoints increased to 5000

### DIFF
--- a/src/main/resources/DeploymentSpecifics.properties
+++ b/src/main/resources/DeploymentSpecifics.properties
@@ -51,3 +51,6 @@ zaakbrug.staging.zaken-api.root-url=http://localhost:9002/zaken/api/v1/
 zaakbrug.staging.documenten-api.root-url=http://localhost:9002/documenten/api/v1/
 zaakbrug.staging.catalogi-api.root-url=http://localhost:9002/catalogi/api/v1/
 zaakbrug.staging.besluiten-api.root-url=http://localhost:9002/besluiten/api/v1/
+
+# Increase the number of checkpoints
+ibistesttool.maxCheckpoints=5000


### PR DESCRIPTION
The default value of number of checkpoints is 2500. We increased it to 5000 for Zaakbrug.