### PR TITLE
perf: forEachChildElementPipe pipes execute in parallel without ignoring errors

### DIFF
--- a/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
@@ -37,9 +37,9 @@
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
 
-            <!-- https://github.com/ibissource/zaakbrug/issues/149 -->
             <ForEachChildElementPipe name="ZgwZaakInformatieObjectenIterator"
-                elementXPathExpression="/ZgwZaakInformatieObjecten/ZgwZaakInformatieObject">
+                elementXPathExpression="/ZgwZaakInformatieObjecten/ZgwZaakInformatieObject"
+                parallel="true">
                 <IbisLocalSender
                     name="CallHandleZgwZaakInformatieObjecten"
                     javaListener="HandleZgwZaakInformatieObjecten">

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByOmschrijving.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByOmschrijving.xml
@@ -17,7 +17,8 @@
                 name="ZaakTypeInformatieObjectTypeUrlIterator"
                 getInputFromSessionKey="ZgwZaakType"
                 storeResultInSessionKey="ZgwInformatieObjectTypen"
-                elementXPathExpression="/ZgwZaakType/informatieobjecttypen">
+                elementXPathExpression="/ZgwZaakType/informatieobjecttypen"
+                parallel="true" >
                 <IbisLocalSender
                     name="GetZgwInformatieObjectTypeByUrlLocalSender"
                     javaListener="GetZgwInformatieObjectTypeByUrl">

--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -362,10 +362,10 @@
                 <Forward name="success" path="PostStatusIterator"/>
             </XsltPipe>
 
-            <!-- https://github.com/ibissource/zaakbrug/issues/144 -->
             <ForEachChildElementPipe name="PostStatusIterator"
                 getInputFromSessionKey="NewStatuses"
-                elementXPathExpression="ZgwStatussen/ZgwStatus">
+                elementXPathExpression="ZgwStatussen/ZgwStatus"
+                parallel="true">
                 <IbisLocalSender
                     name="PostZgwStatusLocalSender"
                     javaListener="Zaken_PostZgwStatus">


### PR DESCRIPTION
Because we have fixed the issue about the parallel=true attribute, we revert the quick change back (which was removing the parallel attribute) and added the parallel attribute back to the related pipes.

The issues which were for quick solutions are:
#144 and #149 