### PR TITLE
test: add delay to prevent inconsistent errors

### DIFF
--- a/e2e/SoapUI/zaakbrug-e2e-soapui-project.xml
+++ b/e2e/SoapUI/zaakbrug-e2e-soapui-project.xml
@@ -7861,6 +7861,12 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue('DocumentBa
           </con:request>
         </con:config>
       </con:testStep>
+      <con:testStep type="delay" name="Delay" id="0fa7d16e-14dc-42c5-8099-4f14d85a4d31">
+        <con:settings/>
+        <con:config>
+          <delay>1000</delay>
+        </con:config>
+      </con:testStep>
       <con:testStep type="request" id="fbfc19b1-8f1e-48f7-8364-4a9ba2e0bfc9" name="11-zds-updateZaak_Lk01-Einde">
         <con:settings/>
         <con:config xsi:type="con:RequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">


### PR DESCRIPTION
It appears that issue #262 is a situation in which the system works correctly but the test case does not.
The intent of the pipe that causes the failure is to prevent situations in which the status is updated at a point in time that does not count as being "in the future". 

So in some situations the SoapUI testcases would work so quick that they would create and then update a few milliseconds later. Since the system does not count in milliseconds but in seconds, both the creation and update would show as happening in the same second. Being in the same second does not constitute being "in the future" and therefore caused the failure of the tests. A simple delay of anywhere between 500 and 1000ms (decided to go with 1000 for certainty) will prevent this from occurring.