### PR TITLE
refactor: processing of zds statusses is no longer done in parallel

### DIFF
--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -395,8 +395,7 @@
 
             <ForEachChildElementPipe name="PostStatusIterator"
                 getInputFromSessionKey="NewStatuses"
-                elementXPathExpression="ZgwStatussen/ZgwStatus"
-                parallel="true">
+                elementXPathExpression="ZgwStatussen/ZgwStatus">
                 <IbisLocalSender
                     name="PostZgwStatusLocalSender"
                     javaListener="Zaken_PostZgwStatus"


### PR DESCRIPTION
There is only one active parallel execution in the flow of CreeerZaak request and it is in PostStatusIterator pipe in SetResultaatAndStatus adapter. It has been removed and the tests have been run again.