### PR TITLE
refactor: move processing of zaak relationships to the end of creeerZaak and updateZaak so that the more critical resultaat and statussen are processed first

### DIFF
--- a/src/main/configurations/Translate/Configuration_CreeerZaak_LK01.xml
+++ b/src/main/configurations/Translate/Configuration_CreeerZaak_LK01.xml
@@ -207,15 +207,34 @@
                         <Param name="PostZgwZaakResult" sessionKey="PostZgwZaakResult" type="DOMDOC"/>
                     </Param>
                 </IbisLocalSender>
-                <Forward name="success" path="CheckForHeeftBetrekkingOpAndere"/>
+                <Forward name="success" path="CallSetResultaatAndStatus"/>
                 <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
+
+            <SenderPipe
+                name="CallSetResultaatAndStatus"
+                getInputFromSessionKey="originalMessage"
+                storeResultInSessionKey="SetResultaatAndStatusResult">
+                <IbisLocalSender
+                    name="CallSetResultaatAndStatusSender"
+                    javaListener="SetResultaatAndStatus"
+                    returnedSessionKeys="Error">
+                    <Param name="ZgwZaakType" xpathExpression="$GetZaakTypeResult/ZgwZaakTypen/ZgwZaakType" type="DOMDOC">
+                        <Param name="GetZaakTypeResult" sessionKey="GetZaakTypeResult" type="DOMDOC"/>
+                    </Param>                  
+                    <Param name="ZaakUrl" xpathExpression="$PostZgwZaakResult/ZgwZaak/url">
+                        <Param name="PostZgwZaakResult" sessionKey="PostZgwZaakResult" type="DOMDOC"/>
+                    </Param>
+                </IbisLocalSender>
+                <Forward name="success" path="CheckForHeeftBetrekkingOpAndere"/>
+                <Forward name="exception" path="UncaughtException" />
+            </SenderPipe>
 
             <XmlIfPipe name="CheckForHeeftBetrekkingOpAndere"
                 getInputFromSessionKey="originalMessage"
                 xpathExpression="/zakLk01/object/heeftBetrekkingOpAndere/gerelateerde[string-length(identificatie) > 0]"
                 thenForwardName="AndereZaakIterator"
-                elseForwardName="CallSetResultaatAndStatus">
+                elseForwardName="EXIT">
             </XmlIfPipe>
 
             <ForEachChildElementPipe name="AndereZaakIterator"
@@ -254,27 +273,8 @@
                     <Param name="Url" xpathExpression="ZgwZaak/url" defaultValue="&lt;dummy/&gt;" />
                     <Param name="AndereUrls" sessionKey="AndereZakenResult" defaultValue="&lt;dummy/&gt;"/>
                 </IbisLocalSender>
-                <Forward name="success" path="CallSetResultaatAndStatus"/>
-                <Forward name="exception" path="EXCEPTION" />
-            </SenderPipe>
-
-            <SenderPipe
-                name="CallSetResultaatAndStatus"
-                getInputFromSessionKey="originalMessage"
-                storeResultInSessionKey="SetResultaatAndStatusResult">
-                <IbisLocalSender
-                    name="CallSetResultaatAndStatusSender"
-                    javaListener="SetResultaatAndStatus"
-                    returnedSessionKeys="Error">
-                    <Param name="ZgwZaakType" xpathExpression="$GetZaakTypeResult/ZgwZaakTypen/ZgwZaakType" type="DOMDOC">
-                        <Param name="GetZaakTypeResult" sessionKey="GetZaakTypeResult" type="DOMDOC"/>
-                    </Param>                  
-                    <Param name="ZaakUrl" xpathExpression="$PostZgwZaakResult/ZgwZaak/url">
-                        <Param name="PostZgwZaakResult" sessionKey="PostZgwZaakResult" type="DOMDOC"/>
-                    </Param>
-                </IbisLocalSender>
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="UncaughtException" />
+                <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
 
             <XsltPipe 

--- a/src/main/configurations/Translate/Configuration_UpdateZaak_LK01.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZaak_LK01.xml
@@ -219,15 +219,39 @@
                         <Param name="GetZgwZaaktypeByUrlResult" sessionKey="GetZgwZaaktypeByUrlResult" type="DOMDOC"/>
                     </Param>
                 </IbisLocalSender>
-                <Forward name="success" path="CheckForHeeftBetrekkingOpAndere"/>
+                <Forward name="success" path="WrapZdsWordtZaak"/>
                 <Forward name="exception" path="EXCEPTION" />
             </ForEachChildElementPipe>  
-            
+
+            <XsltPipe
+                name="WrapZdsWordtZaak"
+                getInputFromSessionKey="ZdsWordtZaak"
+                removeNamespaces="true"
+                skipEmptyTags="true"
+                styleSheetName="UpdateZaak_LK01/xsl/WrapZdsWordtZaak.xslt"
+                >
+                <Forward name="success" path="CallSetResultaatAndStatus"/>
+            </XsltPipe>
+
+            <SenderPipe
+                name="CallSetResultaatAndStatus"
+                storeResultInSessionKey="SetResultaatAndStatusResult">
+                <IbisLocalSender
+                    name="CallSetResultaatAndStatusSender"
+                    javaListener="SetResultaatAndStatus"
+                    returnedSessionKeys="Error">
+                    <Param name="ZgwZaakType" sessionKey="GetZgwZaaktypeByUrlResult" type="DOMDOC"/>                   
+                    <Param name="ZaakUrl" sessionKey="ZgwZaakUrl"/>
+                </IbisLocalSender>
+                <Forward name="success" path="CheckForHeeftBetrekkingOpAndere"/>
+                <Forward name="exception" path="EXCEPTION" />
+            </SenderPipe>
+
             <XmlIfPipe name="CheckForHeeftBetrekkingOpAndere"
                 getInputFromSessionKey="originalMessage"
                 xpathExpression="/zakLk01/object/heeftBetrekkingOpAndere/gerelateerde[string-length(identificatie) > 0]"
                 thenForwardName="AndereZaakIterator"
-                elseForwardName="WrapZdsWordtZaak">
+                elseForwardName="EXIT">
             </XmlIfPipe>
 
             <ForEachChildElementPipe name="AndereZaakIterator"
@@ -265,30 +289,6 @@
                     returnedSessionKeys="Error">
                     <Param name="Url" sessionKey="ZgwZaakUrl" defaultValue="&lt;dummy/&gt;" />
                     <Param name="AndereUrls" sessionKey="AndereZakenResult" defaultValue="&lt;dummy/&gt;"/>
-                </IbisLocalSender>
-                <Forward name="success" path="WrapZdsWordtZaak"/>
-                <Forward name="exception" path="EXCEPTION" />
-            </SenderPipe>
-
-            <XsltPipe
-                name="WrapZdsWordtZaak"
-                getInputFromSessionKey="ZdsWordtZaak"
-                removeNamespaces="true"
-                skipEmptyTags="true"
-                styleSheetName="UpdateZaak_LK01/xsl/WrapZdsWordtZaak.xslt"
-                >
-                <Forward name="success" path="CallSetResultaatAndStatus"/>
-            </XsltPipe>
-
-            <SenderPipe
-                name="CallSetResultaatAndStatus"
-                storeResultInSessionKey="SetResultaatAndStatusResult">
-                <IbisLocalSender
-                    name="CallSetResultaatAndStatusSender"
-                    javaListener="SetResultaatAndStatus"
-                    returnedSessionKeys="Error">
-                    <Param name="ZgwZaakType" sessionKey="GetZgwZaaktypeByUrlResult" type="DOMDOC"/>                   
-                    <Param name="ZaakUrl" sessionKey="ZgwZaakUrl"/>
                 </IbisLocalSender>
                 <Forward name="success" path="EXIT"/>
                 <Forward name="exception" path="EXCEPTION" />


### PR DESCRIPTION
- The pipes which are handling to link the cases each other are moved to the end of the creeerZaak and updateZaak adapters.