### PR TITLE
fix: incorrect reference to geefLijstZaakDocumenten in errormessage when retrieving a zaak by identificatie

### DIFF
--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -78,7 +78,7 @@
                 storeResultInSessionKey="Error">
                 <Param name="cause" sessionKey="Error" type="DOMDOC" />
                 <Param name="code" value="TechnicalError" /> 
-                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in geefLijstZaakDocumenten" />
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaakByIdentificatie" />
                 <Param name="detailsXml" type="DOMDOC"/>
                 <Forward name="success" path="EXCEPTION" />
                 <Forward name="exception" path="EXCEPTION" />


### PR DESCRIPTION
Concluded that the errormessage that appeared in cases where GetZgwZaakByIdentificatie was called and no zaak was found, was incorrect. 