### PR TITLE
fix: geefLijstZaakdocumenten should not return an error response when the zaak can't be found

### DIFF
--- a/e2e/SoapUI/zaakbrug-e2e-soapui-project.xml
+++ b/e2e/SoapUI/zaakbrug-e2e-soapui-project.xml
@@ -17474,6 +17474,317 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue( 'JwtToken'
         </con:property>
       </con:properties>
     </con:testCase>
+    <con:testCase id="9c49c62c-52df-41e8-8205-43940804bda1" failOnError="false" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="5-TestCase ShouldReturnNoErrorWhenNoZaakFound" searchProperties="true" timeout="0" wsrmEnabled="false" wsrmVersion="1.0" wsrmAckTo="" amfAuthorisation="false" amfEndpoint="" amfLogin="" amfPassword="">
+      <con:settings/>
+      <con:testStep type="properties" name="Properties" id="6b939893-89c9-40d3-b192-2a607750ffb4">
+        <con:settings/>
+        <con:config xsi:type="con:PropertiesStep" saveFirst="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <con:properties>
+            <con:property>
+              <con:name>ZaakIdentificatie</con:name>
+              <con:value/>
+            </con:property>
+          </con:properties>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="request" id="3188f63e-55c0-4e49-844b-946b876218f7" name="01-zds-genereerZaakIdentificatie_Di02">
+        <con:settings/>
+        <con:config xsi:type="con:RequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <con:interface>ZdsVrijeBerichten</con:interface>
+          <con:operation>genereerZaakIdentificatie_Di02</con:operation>
+          <con:request name="01-zds-genereerZaakIdentificatie_Di02" outgoingWss="" incomingWss="" timeout="" sslKeystore="" useWsAddressing="false" useWsReliableMessaging="false" wssPasswordType="" id="78a97417-a2f7-4fe6-87ad-6af33391b0e1">
+            <con:settings>
+              <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+              <con:setting id="com.eviware.soapui.impl.support.AbstractHttpRequest@dump-file"/>
+            </con:settings>
+            <con:encoding>UTF-8</con:encoding>
+            <con:endpoint>${#Project#ZaakbrugEndpoint}translate/generic/zds/VrijBericht</con:endpoint>
+            <con:request><![CDATA[<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">\r
+   <s:Body>\r
+      <genereerZaakIdentificatie_Di02 xmlns="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\r
+         <stuurgegevens>\r
+            <StUF:berichtcode>Di02</StUF:berichtcode>\r
+            <StUF:zender>\r
+               <StUF:organisatie>1900</StUF:organisatie>\r
+               <StUF:applicatie>GISVG</StUF:applicatie>\r
+            </StUF:zender>\r
+            <StUF:ontvanger>\r
+               <StUF:organisatie>1900</StUF:organisatie>\r
+               <StUF:applicatie>ZDS</StUF:applicatie>\r
+            </StUF:ontvanger>\r
+            <StUF:referentienummer>${=java.util.UUID.randomUUID().toString() }</StUF:referentienummer>\r
+            <StUF:tijdstipBericht>${=import java.text.SimpleDateFormat; SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmssSS"); sdf.setTimeZone(TimeZone.getTimeZone("${#Project#ZdsTimezone}")); sdf.format(new Date());}</StUF:tijdstipBericht>\r
+            <StUF:functie>genereerZaakidentificatie</StUF:functie>\r
+         </stuurgegevens>\r
+      </genereerZaakIdentificatie_Di02>\r
+   </s:Body>\r
+</s:Envelope>]]></con:request>
+            <con:assertion type="SOAP Response" id="d95790e3-4684-4e55-bc88-a3472c2a786b" name="SOAP Response"/>
+            <con:assertion type="Schema Compliance" id="7c41213e-fa45-4a54-9b26-a2aae7cae18f" name="Schema Compliance">
+              <con:configuration/>
+            </con:assertion>
+            <con:assertion type="SOAP Fault Assertion" id="18ca3e91-13ed-4d5d-951f-992518c27752" name="Not SOAP Fault"/>
+            <con:credentials>
+              <con:authType>No Authorization</con:authType>
+            </con:credentials>
+            <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+            <con:jmsPropertyConfig/>
+            <con:wsaConfig mustUnderstand="NONE" version="200508" action="http://www.egem.nl/StUF/sector/zkn/0310/genereerZaakIdentificatie_Di02"/>
+            <con:wsrmConfig version="1.2"/>
+          </con:request>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="transfer" name="01a-TransferZaakIdentificatie" id="e79bfade-1f06-4760-bc6c-d8b8189f7726">
+        <con:settings/>
+        <con:config xsi:type="con:PropertyTransfersStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <con:transfers setNullOnMissingSource="true" transferTextContent="true" failOnError="true" ignoreEmpty="false" transferToAll="false" entitize="false" transferChildNodes="false" disabled="false">
+            <con:name>TransferZaakIdentificatie</con:name>
+            <con:sourceType>Response</con:sourceType>
+            <con:sourceStep>01-zds-genereerZaakIdentificatie_Di02</con:sourceStep>
+            <con:sourcePath>declare namespace ZKN="http://www.egem.nl/StUF/sector/zkn/0310";
+//ZKN:identificatie[1]</con:sourcePath>
+            <con:targetType>ZaakIdentificatie</con:targetType>
+            <con:targetStep>Properties</con:targetStep>
+            <con:targetPath/>
+            <con:type>XPATH</con:type>
+            <con:upgraded>true</con:upgraded>
+          </con:transfers>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="request" id="e01dbb3b-d69b-4bb5-a3c5-dd8fa13334c5" name="03-zds-geefZaakdetails_Lv01-ShouldReturnNoErrorWithNotExistingZaakId">
+        <con:settings/>
+        <con:config xsi:type="con:RequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <con:interface>ZdsBeantwoordVraag</con:interface>
+          <con:operation>geefZaakdetails_Lv01</con:operation>
+          <con:request name="03-zds-geefZaakdetails_Lv01-ShouldReturnNoErrorWithNotExistingZaakId" outgoingWss="" incomingWss="" timeout="" sslKeystore="" useWsAddressing="false" useWsReliableMessaging="false" wssPasswordType="" id="b86f0444-e5bf-4a09-97a2-3d650e0b93ff">
+            <con:settings>
+              <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+            </con:settings>
+            <con:encoding>UTF-8</con:encoding>
+            <con:endpoint>${#Project#ZaakbrugEndpoint}translate/generic/zds/BeantwoordVraag</con:endpoint>
+            <con:request><![CDATA[<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">\r
+   <s:Body>\r
+      <zakLv01 xmlns="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:BG="http://www.egem.nl/StUF/sector/bg/0310" xmlns:xlink="http://www.w3.org/1999/xlink">\r
+         <stuurgegevens>\r
+            <StUF:berichtcode>Lv01</StUF:berichtcode>\r
+            <StUF:zender>\r
+               <StUF:organisatie>1900</StUF:organisatie>\r
+               <StUF:applicatie>GISVG</StUF:applicatie>\r
+            </StUF:zender>\r
+            <StUF:ontvanger>\r
+               <StUF:organisatie>1900</StUF:organisatie>\r
+               <StUF:applicatie>ZDS</StUF:applicatie>\r
+            </StUF:ontvanger>\r
+            <StUF:referentienummer>${=java.util.UUID.randomUUID().toString() }</StUF:referentienummer>\r
+            <StUF:tijdstipBericht>${=import java.text.SimpleDateFormat; SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmssSS"); sdf.setTimeZone(TimeZone.getTimeZone("${#Project#ZdsTimezone}")); sdf.format(new Date());}</StUF:tijdstipBericht>\r
+            <StUF:entiteittype>ZAK</StUF:entiteittype>\r
+         </stuurgegevens>\r
+         <parameters>\r
+            <StUF:sortering>0</StUF:sortering>\r
+            <StUF:indicatorVervolgvraag>false</StUF:indicatorVervolgvraag>\r
+         </parameters>\r
+         <gelijk StUF:entiteittype="ZAK">\r
+            <identificatie>${Properties#ZaakIdentificatie}</identificatie>\r
+         </gelijk>\r
+         <scope>\r
+            <object StUF:entiteittype="ZAK">\r
+               <identificatie xsi:nil="true"/>\r
+               <omschrijving xsi:nil="true"/>\r
+               <toelichting xsi:nil="true"/>\r
+               <kenmerk>\r
+                  <kenmerk xsi:nil="true"/>\r
+                  <bron xsi:nil="true"/>\r
+               </kenmerk>\r
+               <anderZaakObject>\r
+                  <omschrijving xsi:nil="true"/>\r
+                  <aanduiding xsi:nil="true"/>\r
+                  <lokatie xsi:nil="true"/>\r
+                  <registratie xsi:nil="true"/>\r
+               </anderZaakObject>\r
+               <resultaat>\r
+                  <omschrijving xsi:nil="true"/>\r
+                  <toelichting xsi:nil="true"/>\r
+               </resultaat>\r
+               <startdatum xsi:nil="true"/>\r
+               <registratiedatum xsi:nil="true"/>\r
+               <publicatiedatum xsi:nil="true"/>\r
+               <einddatumGepland xsi:nil="true"/>\r
+               <uiterlijkeEinddatum xsi:nil="true"/>\r
+               <einddatum xsi:nil="true"/>\r
+               <opschorting>\r
+                  <indicatie xsi:nil="true"/>\r
+                  <reden xsi:nil="true"/>\r
+               </opschorting>\r
+               <verlenging>\r
+                  <duur xsi:nil="true"/>\r
+                  <reden xsi:nil="true"/>\r
+               </verlenging>\r
+               <betalingsIndicatie xsi:nil="true"/>\r
+               <laatsteBetaaldatum xsi:nil="true"/>\r
+               <archiefnominatie xsi:nil="true"/>\r
+               <datumVernietigingDossier xsi:nil="true"/>\r
+               <zaakniveau xsi:nil="true"/>\r
+               <deelzakenIndicatie xsi:nil="true"/>\r
+               <isVan StUF:entiteittype="ZAKZKT">\r
+                  <gerelateerde StUF:entiteittype="ZKT">\r
+                     <omschrijving xsi:nil="true"/>\r
+                     <code xsi:nil="true"/>\r
+                     <omschrijvingGeneriek xsi:nil="true"/>\r
+                     <zaakcategorie xsi:nil="true"/>\r
+                     <trefwoord xsi:nil="true"/>\r
+                     <doorlooptijd xsi:nil="true"/>\r
+                     <servicenorm xsi:nil="true"/>\r
+                     <archiefcode xsi:nil="true"/>\r
+                     <vertrouwelijkAanduiding xsi:nil="true"/>\r
+                     <publicatieIndicatie xsi:nil="true"/>\r
+                     <publicatietekst xsi:nil="true"/>\r
+                  </gerelateerde>\r
+               </isVan>\r
+               <heeftBetrekkingOp StUF:entiteittype="ZAKOBJ">\r
+                  <gerelateerde/>\r
+               </heeftBetrekkingOp>\r
+               <heeftAlsBelanghebbende StUF:entiteittype="ZAKBTRBLH">\r
+                  <gerelateerde/>\r
+               </heeftAlsBelanghebbende>\r
+               <heeftAlsGemachtigde StUF:entiteittype="ZAKBTRGMC">\r
+                  <gerelateerde/>\r
+               </heeftAlsGemachtigde>\r
+               <heeftAlsInitiator StUF:entiteittype="ZAKBTRINI">\r
+                  <gerelateerde/>\r
+               </heeftAlsInitiator>\r
+               <heeftAlsUitvoerende StUF:entiteittype="ZAKBTRUTV">\r
+                  <gerelateerde/>\r
+               </heeftAlsUitvoerende>\r
+               <heeftAlsVerantwoordelijke StUF:entiteittype="ZAKBTRVRA">\r
+                  <gerelateerde/>\r
+               </heeftAlsVerantwoordelijke>\r
+               <heeftAlsOverigBetrokkene StUF:entiteittype="ZAKBTROVR">\r
+                  <gerelateerde/>\r
+               </heeftAlsOverigBetrokkene>\r
+            </object>\r
+         </scope>\r
+      </zakLv01>\r
+   </s:Body>\r
+</s:Envelope>]]></con:request>
+            <con:assertion type="SOAP Response" id="a5bb9a97-6aff-4a26-bd8c-283295080f00" name="SOAP Response"/>
+            <con:assertion type="Schema Compliance" id="ed311230-3e49-4b1f-ad19-4ff7dad1ecf2" name="Schema Compliance">
+              <con:configuration/>
+            </con:assertion>
+            <con:assertion type="SOAP Fault Assertion" id="ecf082e3-2bda-418f-bc9e-32a49965d93b" name="Not SOAP Fault"/>
+            <con:assertion type="XPath Match" id="17a1e7d1-da63-4ca9-a8b6-1c1a8c64d84b" name="CheckObjectElementIsEmpty">
+              <con:configuration>
+                <path>count(//*:zakLa01/*:antwoord/*:object/*)</path>
+                <content>0</content>
+                <allowWildcards>false</allowWildcards>
+                <ignoreNamspaceDifferences>false</ignoreNamspaceDifferences>
+                <ignoreComments>false</ignoreComments>
+              </con:configuration>
+            </con:assertion>
+            <con:credentials>
+              <con:authType>No Authorization</con:authType>
+            </con:credentials>
+            <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+            <con:jmsPropertyConfig/>
+            <con:wsaConfig mustUnderstand="NONE" version="200508" action="http://www.egem.nl/StUF/sector/zkn/0310/geefZaakdetails_Lv01"/>
+            <con:wsrmConfig version="1.2"/>
+          </con:request>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="request" id="bb0277e9-9d1e-4f99-a115-c3d06ab2aba0" name="04-zds-geefLijstZaakdocumenten_Lv01-ShouldReturnNoErrorWithNotExistingZaakId">
+        <con:settings/>
+        <con:config xsi:type="con:RequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <con:interface>ZdsBeantwoordVraag</con:interface>
+          <con:operation>geefLijstZaakdocumenten_Lv01</con:operation>
+          <con:request name="04-zds-geefLijstZaakdocumenten_Lv01-ShouldReturnNoErrorWithNotExistingZaakId" outgoingWss="" incomingWss="" timeout="" sslKeystore="" useWsAddressing="false" useWsReliableMessaging="false" wssPasswordType="" id="a3e62795-102e-4f2a-bef6-2de7f0c1a7e0">
+            <con:settings>
+              <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+              <con:setting id="com.eviware.soapui.impl.support.AbstractHttpRequest@dump-file"/>
+            </con:settings>
+            <con:encoding>UTF-8</con:encoding>
+            <con:endpoint>${#Project#ZaakbrugEndpoint}translate/generic/zds/BeantwoordVraag</con:endpoint>
+            <con:request><![CDATA[<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">\r
+   <s:Body>\r
+      <zakLv01 xmlns="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:BG="http://www.egem.nl/StUF/sector/bg/0310" xmlns:xlink="http://www.w3.org/1999/xlink">\r
+         <stuurgegevens>\r
+            <StUF:berichtcode>Lv01</StUF:berichtcode>\r
+            <StUF:zender>\r
+               <StUF:organisatie>1900</StUF:organisatie>\r
+               <StUF:applicatie>GISVG</StUF:applicatie>\r
+            </StUF:zender>\r
+            <StUF:ontvanger>\r
+               <StUF:organisatie>1900</StUF:organisatie>\r
+               <StUF:applicatie>ZDS</StUF:applicatie>\r
+            </StUF:ontvanger>\r
+            <StUF:referentienummer>${=java.util.UUID.randomUUID().toString() }</StUF:referentienummer>\r
+            <StUF:tijdstipBericht>${=import java.text.SimpleDateFormat; SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmssSS"); sdf.setTimeZone(TimeZone.getTimeZone("${#Project#ZdsTimezone}")); sdf.format(new Date());}</StUF:tijdstipBericht>\r
+            <StUF:entiteittype>ZAK</StUF:entiteittype>\r
+         </stuurgegevens>\r
+         <parameters>\r
+            <StUF:sortering>0</StUF:sortering>\r
+            <StUF:indicatorVervolgvraag>false</StUF:indicatorVervolgvraag>\r
+         </parameters>\r
+         <gelijk StUF:entiteittype="ZAK">\r
+            <identificatie>${Properties#ZaakIdentificatie}</identificatie>\r
+         </gelijk>\r
+         <scope>\r
+            <object StUF:entiteittype="ZAK">\r
+               <identificatie xsi:nil="true"/>\r
+               <heeftRelevant StUF:entiteittype="ZAKEDC">\r
+                  <gerelateerde StUF:entiteittype="EDC">\r
+                     <identificatie xsi:nil="true"/>\r
+                     <creatiedatum xsi:nil="true"/>\r
+                     <ontvangstdatum xsi:nil="true"/>\r
+                     <titel xsi:nil="true"/>\r
+                     <beschrijving xsi:nil="true"/>\r
+                     <formaat xsi:nil="true"/>\r
+                     <taal xsi:nil="true"/>\r
+                     <versie xsi:nil="true"/>\r
+                     <status xsi:nil="true"/>\r
+                     <verzenddatum xsi:nil="true"/>\r
+                     <vertrouwelijkAanduiding xsi:nil="true"/>\r
+                     <auteur xsi:nil="true"/>\r
+                     <link xsi:nil="true"/>\r
+                  </gerelateerde>\r
+                  <titel xsi:nil="true"/>\r
+                  <beschrijving xsi:nil="true"/>\r
+                  <registratiedatum xsi:nil="true"/>\r
+               </heeftRelevant>\r
+            </object>\r
+         </scope>\r
+      </zakLv01>\r
+   </s:Body>\r
+</s:Envelope>]]></con:request>
+            <con:assertion type="SOAP Response" id="b2f3ce38-c4b5-4541-9374-17f6682f16d2" name="SOAP Response"/>
+            <con:assertion type="Schema Compliance" id="d13f39b7-9089-4189-b7de-e7ba35a6002a" name="Schema Compliance">
+              <con:configuration/>
+            </con:assertion>
+            <con:assertion type="SOAP Fault Assertion" id="ba1882c2-f41f-4dc6-a1a3-2d859b772f8a" name="Not SOAP Fault"/>
+            <con:assertion type="XPath Match" id="e315a915-3c43-45e6-b342-71d51836f9be" name="CheckObjectElementIsEmpty">
+              <con:configuration>
+                <path>count(//*:zakLa01/*:antwoord/*:object/*)</path>
+                <content>0</content>
+                <allowWildcards>false</allowWildcards>
+                <ignoreNamspaceDifferences>false</ignoreNamspaceDifferences>
+                <ignoreComments>false</ignoreComments>
+              </con:configuration>
+            </con:assertion>
+            <con:credentials>
+              <con:authType>No Authorization</con:authType>
+            </con:credentials>
+            <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+            <con:jmsPropertyConfig/>
+            <con:wsaConfig mustUnderstand="NONE" version="200508" action="http://www.egem.nl/StUF/sector/zkn/0310/geefLijstZaakdocumenten_Lv01"/>
+            <con:wsrmConfig version="1.2"/>
+          </con:request>
+        </con:config>
+      </con:testStep>
+      <con:properties>
+        <con:property>
+          <con:name>DocumentSizeKb</con:name>
+          <con:value>0.1</con:value>
+        </con:property>
+      </con:properties>
+    </con:testCase>
     <con:testCase id="58919512-9485-4822-8986-f4861cd14c33" failOnError="false" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="TearDown-Delete ZaakTypeOmgevingsvergunning" searchProperties="true" timeout="0" wsrmEnabled="false" wsrmVersion="1.0" wsrmAckTo="" amfAuthorisation="false" amfEndpoint="" amfLogin="" amfPassword="">
       <con:settings/>
       <con:testStep type="properties" name="Properties" id="8c3d318d-bd31-4fe0-acea-cef700648e6e">

--- a/src/main/configurations/Translate/Common/xsl/CreateZakLa01Response.xslt
+++ b/src/main/configurations/Translate/Common/xsl/CreateZakLa01Response.xslt
@@ -25,140 +25,147 @@
                 <StUF:indicatorVervolgvraag><xsl:value-of select="$Parameters/parameters/indicatorVervolgvraag"/></StUF:indicatorVervolgvraag>
             </ZKN:parameters>
             <ZKN:antwoord>
-                <ZKN:object StUF:entiteittype="ZAK">
-                    <xsl:if test="root/identificatie">
-                        <ZKN:identificatie><xsl:value-of select="root/identificatie"/></ZKN:identificatie>
-                    </xsl:if>
-                    <xsl:if test="root/omschrijving">
-                        <ZKN:omschrijving><xsl:value-of select="root/omschrijving"/></ZKN:omschrijving>
-                    </xsl:if>
-                    <xsl:if test="root/toelichting">
-                        <ZKN:toelichting><xsl:value-of select="root/toelichting"/></ZKN:toelichting>
-                    </xsl:if>
-                    <xsl:apply-templates select="root/kenmerk"/>
-                    <!-- <xsl:apply-templates select="root/anderZaakObject"/> --> <!-- not provided -->
-                    <!-- <ZKN:resultaat>
-                        <ZKN:omschrijving><xsl:value-of select="root/resultaat/omschrijving"/></ZKN:omschrijving>
-                        <ZKN:toelichting><xsl:value-of select="root/resultaat/toelichting"/></ZKN:toelichting>
-                    </ZKN:resultaat> -->
-                    <xsl:if test="root/startdatum">
-                        <ZKN:startdatum><xsl:value-of select="root/startdatum"/></ZKN:startdatum>
-                    </xsl:if>
-                    <xsl:if test="root/registratiedatum">
-                        <ZKN:registratiedatum><xsl:value-of select="root/registratiedatum"/></ZKN:registratiedatum>
-                    </xsl:if>
-                    <xsl:if test="root/publicatiedatum">
-                        <ZKN:publicatiedatum><xsl:value-of select="root/publicatiedatum"/></ZKN:publicatiedatum>
-                    </xsl:if>
-                    <xsl:if test="root/einddatumGepland">
-                        <ZKN:einddatumGepland><xsl:value-of select="root/einddatumGepland"/></ZKN:einddatumGepland>
-                    </xsl:if>
-                    <xsl:if test="root/uiterlijkeEinddatum">
-                        <ZKN:uiterlijkeEinddatum><xsl:value-of select="root/uiterlijkeEinddatum"/></ZKN:uiterlijkeEinddatum>
-                    </xsl:if>
-                    <xsl:if test="root/einddatum">
-                        <ZKN:einddatum><xsl:value-of select="root/einddatum"/></ZKN:einddatum>
-                    </xsl:if>
-                    <xsl:if test="root/opschorting">
-                        <ZKN:opschorting>
-                            <ZKN:indicatie><xsl:value-of select="root/opschorting/indicatie"/></ZKN:indicatie>
-                            <ZKN:reden><xsl:value-of select="root/opschorting/reden"/></ZKN:reden>
-                        </ZKN:opschorting>
-                    </xsl:if>
-                    <xsl:if test="root/verlenging">
-                        <ZKN:verlenging>
-                            <ZKN:duur><xsl:value-of select="root/verlenging/duur"/></ZKN:duur>
-                            <ZKN:reden><xsl:value-of select="root/verlenging/reden"/></ZKN:reden>
-                        </ZKN:verlenging>
-                    </xsl:if>
-                    <xsl:if test="root/betalingsIndicatie">
-                        <ZKN:betalingsIndicatie><xsl:value-of select="root/betalingsIndicatie"/></ZKN:betalingsIndicatie>
-                    </xsl:if>
-                    <xsl:if test="root/laatsteBetaaldatum">
-                        <ZKN:laatsteBetaaldatum><xsl:value-of select="root/laatsteBetaaldatum"/></ZKN:laatsteBetaaldatum>
-                    </xsl:if>
-                    <xsl:if test="root/archiefnominatie">
-                        <ZKN:archiefnominatie><xsl:value-of select="root/archiefnominatie"/></ZKN:archiefnominatie>
-                    </xsl:if>
-                    <xsl:if test="root/datumVernietigingDossier">
-                        <ZKN:datumVernietigingDossier><xsl:value-of select="root/datumVernietigingDossier"/></ZKN:datumVernietigingDossier>
-                    </xsl:if>
-                    <xsl:if test="root/zaakniveau">
-                        <ZKN:zaakniveau><xsl:value-of select="root/zaakniveau"/></ZKN:zaakniveau>
-                    </xsl:if>
-                    <xsl:if test="root/deelzakenIndicatie">
-                        <ZKN:deelzakenIndicatie><xsl:value-of select="root/deelzakenIndicatie"/></ZKN:deelzakenIndicatie>
-                    </xsl:if>
-                    <xsl:apply-templates select="root/isVan/gerelateerde"/>
-                    <xsl:for-each select="root/heeftBetrekkingOp">
-                        <ZKN:heeftBetrekkingOp StUF:entiteittype="ZAKOBJ">
-                            <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/vestiging"/>
-                            <xsl:apply-templates select="gerelateerde/medewerker"/>
-                            <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
-                        </ZKN:heeftBetrekkingOp>
-                    </xsl:for-each>
-                    <xsl:for-each select="root/heeftAlsBelanghebbende">
-                        <ZKN:heeftAlsBelanghebbende StUF:entiteittype="ZAKBTRBLH">
-                            <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/vestiging"/>
-                            <xsl:apply-templates select="gerelateerde/medewerker"/>
-                            <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
-                        </ZKN:heeftAlsBelanghebbende>
-                    </xsl:for-each>
-                    <xsl:for-each select="root/heeftAlsGemachtigde">
-                        <ZKN:heeftAlsGemachtigde StUF:entiteittype="ZAKBTRGMC">
-                            <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/vestiging"/>
-                            <xsl:apply-templates select="gerelateerde/medewerker"/>
-                            <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
-                        </ZKN:heeftAlsGemachtigde>
-                    </xsl:for-each>
-                    <xsl:for-each select="root/heeftAlsInitiator">
-                        <ZKN:heeftAlsInitiator StUF:entiteittype="ZAKBTRINI">
-                            <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/vestiging"/>
-                            <xsl:apply-templates select="gerelateerde/medewerker"/>
-                            <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
-                        </ZKN:heeftAlsInitiator>
-                    </xsl:for-each>
-                    <xsl:for-each select="root/heeftAlsUitvoerende">
-                        <ZKN:heeftAlsUitvoerende StUF:entiteittype="ZAKBTRUTV">
-                            <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/vestiging"/>
-                            <xsl:apply-templates select="gerelateerde/medewerker"/>
-                            <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
-                        </ZKN:heeftAlsUitvoerende>
-                    </xsl:for-each>
-                    <xsl:for-each select="root/heeftAlsVerantwoordelijke">
-                        <ZKN:heeftAlsVerantwoordelijke StUF:entiteittype="ZAKBTRVRA">
-                            <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/vestiging"/>
-                            <xsl:apply-templates select="gerelateerde/medewerker"/>
-                            <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
-                        </ZKN:heeftAlsVerantwoordelijke>
-                    </xsl:for-each>
-                    <xsl:for-each select="root/heeftAlsOverigBetrokkene">
-                        <ZKN:heeftAlsOverigBetrokkene StUF:entiteittype="ZAKBTROVR">
-                            <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
-                            <xsl:apply-templates select="gerelateerde/vestiging"/>
-                            <xsl:apply-templates select="gerelateerde/medewerker"/>
-                            <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
-                        </ZKN:heeftAlsOverigBetrokkene>
-                    </xsl:for-each>
-                    <xsl:apply-templates select="root/heeftAlsDeelzaak/gerelateerde"/>
-                    <xsl:apply-templates select="root/heeftAlsHoofdzaak/gerelateerde"/>
-                    <xsl:apply-templates select="root/heeftBetrekkingOpAndere/gerelateerde"/>
-                    <xsl:apply-templates select="root/heeft"/>
-                    <xsl:apply-templates select="results/result/heeftRelevant"/>
-                </ZKN:object>
+                <xsl:choose>
+                    <xsl:when test="name(/*) != 'root' and name(/*) != 'results'">
+                        <ZKN:object StUF:entiteittype="ZAK" StUF:noValue="waardeOnbekend" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <ZKN:object StUF:entiteittype="ZAK">
+                            <xsl:if test="root/identificatie">
+                                <ZKN:identificatie><xsl:value-of select="root/identificatie"/></ZKN:identificatie>
+                            </xsl:if>
+                            <xsl:if test="root/omschrijving">
+                                <ZKN:omschrijving><xsl:value-of select="root/omschrijving"/></ZKN:omschrijving>
+                            </xsl:if>
+                            <xsl:if test="root/toelichting">
+                                <ZKN:toelichting><xsl:value-of select="root/toelichting"/></ZKN:toelichting>
+                            </xsl:if>
+                            <xsl:apply-templates select="root/kenmerk"/>
+                            <!-- <xsl:apply-templates select="root/anderZaakObject"/> --> <!-- not provided -->
+                            <!-- <ZKN:resultaat>
+                                <ZKN:omschrijving><xsl:value-of select="root/resultaat/omschrijving"/></ZKN:omschrijving>
+                                <ZKN:toelichting><xsl:value-of select="root/resultaat/toelichting"/></ZKN:toelichting>
+                            </ZKN:resultaat> -->
+                            <xsl:if test="root/startdatum">
+                                <ZKN:startdatum><xsl:value-of select="root/startdatum"/></ZKN:startdatum>
+                            </xsl:if>
+                            <xsl:if test="root/registratiedatum">
+                                <ZKN:registratiedatum><xsl:value-of select="root/registratiedatum"/></ZKN:registratiedatum>
+                            </xsl:if>
+                            <xsl:if test="root/publicatiedatum">
+                                <ZKN:publicatiedatum><xsl:value-of select="root/publicatiedatum"/></ZKN:publicatiedatum>
+                            </xsl:if>
+                            <xsl:if test="root/einddatumGepland">
+                                <ZKN:einddatumGepland><xsl:value-of select="root/einddatumGepland"/></ZKN:einddatumGepland>
+                            </xsl:if>
+                            <xsl:if test="root/uiterlijkeEinddatum">
+                                <ZKN:uiterlijkeEinddatum><xsl:value-of select="root/uiterlijkeEinddatum"/></ZKN:uiterlijkeEinddatum>
+                            </xsl:if>
+                            <xsl:if test="root/einddatum">
+                                <ZKN:einddatum><xsl:value-of select="root/einddatum"/></ZKN:einddatum>
+                            </xsl:if>
+                            <xsl:if test="root/opschorting">
+                                <ZKN:opschorting>
+                                    <ZKN:indicatie><xsl:value-of select="root/opschorting/indicatie"/></ZKN:indicatie>
+                                    <ZKN:reden><xsl:value-of select="root/opschorting/reden"/></ZKN:reden>
+                                </ZKN:opschorting>
+                            </xsl:if>
+                            <xsl:if test="root/verlenging">
+                                <ZKN:verlenging>
+                                    <ZKN:duur><xsl:value-of select="root/verlenging/duur"/></ZKN:duur>
+                                    <ZKN:reden><xsl:value-of select="root/verlenging/reden"/></ZKN:reden>
+                                </ZKN:verlenging>
+                            </xsl:if>
+                            <xsl:if test="root/betalingsIndicatie">
+                                <ZKN:betalingsIndicatie><xsl:value-of select="root/betalingsIndicatie"/></ZKN:betalingsIndicatie>
+                            </xsl:if>
+                            <xsl:if test="root/laatsteBetaaldatum">
+                                <ZKN:laatsteBetaaldatum><xsl:value-of select="root/laatsteBetaaldatum"/></ZKN:laatsteBetaaldatum>
+                            </xsl:if>
+                            <xsl:if test="root/archiefnominatie">
+                                <ZKN:archiefnominatie><xsl:value-of select="root/archiefnominatie"/></ZKN:archiefnominatie>
+                            </xsl:if>
+                            <xsl:if test="root/datumVernietigingDossier">
+                                <ZKN:datumVernietigingDossier><xsl:value-of select="root/datumVernietigingDossier"/></ZKN:datumVernietigingDossier>
+                            </xsl:if>
+                            <xsl:if test="root/zaakniveau">
+                                <ZKN:zaakniveau><xsl:value-of select="root/zaakniveau"/></ZKN:zaakniveau>
+                            </xsl:if>
+                            <xsl:if test="root/deelzakenIndicatie">
+                                <ZKN:deelzakenIndicatie><xsl:value-of select="root/deelzakenIndicatie"/></ZKN:deelzakenIndicatie>
+                            </xsl:if>
+                            <xsl:apply-templates select="root/isVan/gerelateerde"/>
+                            <xsl:for-each select="root/heeftBetrekkingOp">
+                                <ZKN:heeftBetrekkingOp StUF:entiteittype="ZAKOBJ">
+                                    <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/vestiging"/>
+                                    <xsl:apply-templates select="gerelateerde/medewerker"/>
+                                    <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
+                                </ZKN:heeftBetrekkingOp>
+                            </xsl:for-each>
+                            <xsl:for-each select="root/heeftAlsBelanghebbende">
+                                <ZKN:heeftAlsBelanghebbende StUF:entiteittype="ZAKBTRBLH">
+                                    <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/vestiging"/>
+                                    <xsl:apply-templates select="gerelateerde/medewerker"/>
+                                    <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
+                                </ZKN:heeftAlsBelanghebbende>
+                            </xsl:for-each>
+                            <xsl:for-each select="root/heeftAlsGemachtigde">
+                                <ZKN:heeftAlsGemachtigde StUF:entiteittype="ZAKBTRGMC">
+                                    <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/vestiging"/>
+                                    <xsl:apply-templates select="gerelateerde/medewerker"/>
+                                    <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
+                                </ZKN:heeftAlsGemachtigde>
+                            </xsl:for-each>
+                            <xsl:for-each select="root/heeftAlsInitiator">
+                                <ZKN:heeftAlsInitiator StUF:entiteittype="ZAKBTRINI">
+                                    <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/vestiging"/>
+                                    <xsl:apply-templates select="gerelateerde/medewerker"/>
+                                    <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
+                                </ZKN:heeftAlsInitiator>
+                            </xsl:for-each>
+                            <xsl:for-each select="root/heeftAlsUitvoerende">
+                                <ZKN:heeftAlsUitvoerende StUF:entiteittype="ZAKBTRUTV">
+                                    <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/vestiging"/>
+                                    <xsl:apply-templates select="gerelateerde/medewerker"/>
+                                    <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
+                                </ZKN:heeftAlsUitvoerende>
+                            </xsl:for-each>
+                            <xsl:for-each select="root/heeftAlsVerantwoordelijke">
+                                <ZKN:heeftAlsVerantwoordelijke StUF:entiteittype="ZAKBTRVRA">
+                                    <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/vestiging"/>
+                                    <xsl:apply-templates select="gerelateerde/medewerker"/>
+                                    <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
+                                </ZKN:heeftAlsVerantwoordelijke>
+                            </xsl:for-each>
+                            <xsl:for-each select="root/heeftAlsOverigBetrokkene">
+                                <ZKN:heeftAlsOverigBetrokkene StUF:entiteittype="ZAKBTROVR">
+                                    <xsl:apply-templates select="gerelateerde/natuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/nietNatuurlijkPersoon"/>
+                                    <xsl:apply-templates select="gerelateerde/vestiging"/>
+                                    <xsl:apply-templates select="gerelateerde/medewerker"/>
+                                    <xsl:apply-templates select="gerelateerde/organisatorischeEenheid"/>
+                                </ZKN:heeftAlsOverigBetrokkene>
+                            </xsl:for-each>
+                            <xsl:apply-templates select="root/heeftAlsDeelzaak/gerelateerde"/>
+                            <xsl:apply-templates select="root/heeftAlsHoofdzaak/gerelateerde"/>
+                            <xsl:apply-templates select="root/heeftBetrekkingOpAndere/gerelateerde"/>
+                            <xsl:apply-templates select="root/heeft"/>
+                            <xsl:apply-templates select="results/result/heeftRelevant"/>
+                        </ZKN:object>
+                    </xsl:otherwise>
+                </xsl:choose>
             </ZKN:antwoord>
         </ZKN:zakLa01>
 	</xsl:template>

--- a/src/main/configurations/Translate/Configuration_ActualiseerZaakStatus.xml
+++ b/src/main/configurations/Translate/Configuration_ActualiseerZaakStatus.xml
@@ -38,8 +38,9 @@
             </PutInSessionPipe>
 
             <PutInSessionPipe 
-                name="StoreZaakIdentificatie">
-                <Param name="Identificatie" sessionKey="object" xpathExpression="object/identificatie"/>
+                name="StoreZaakIdentificatie"
+                >
+                <Param name="Identificatie" sessionKey="object" xpathExpression="object/identificatie" />
                 <Forward name="success" path="CallGetZgwZaak" />
             </PutInSessionPipe>
             
@@ -53,26 +54,28 @@
                     returnedSessionKeys="Error">
                     <Param name="Identificatie" sessionKey="Identificatie"/>
                 </IbisLocalSender>
-                <Forward name="success" path="CheckForGetZgwZaakResult"/>
+                <Forward name="success" path="ZaakNotFound_Condition"/>
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
 
-            <XmlIfPipe name="CheckForGetZgwZaakResult"
-                xpathExpression="string-length(ZgwZaken) > 0"
+            <XmlIfPipe
+                name="ZaakNotFound_Condition"
+                xpathExpression="string-length(ZgwZaken) = 0"
                 >
-                <Forward name="then" path="CallGetZaakTypeByZaak"/>
-                <Forward name="else" path="BuildErrorMessage"/>
+                <Forward name="then" path="ZaakNotFound_Exception" />
+                <Forward name="else" path="CallGetZaakTypeByZaak" />
             </XmlIfPipe>
 
             <XsltPipe
-                name="BuildErrorMessage"
+                name="ZaakNotFound_Exception"
                 getInputFromFixedValue="&lt;dummy/&gt;"
                 styleSheetName="Common/xsl/BuildError.xsl"
-                storeResultInSessionKey="Error">
+                storeResultInSessionKey="Error"
+                >
                 <Param name="cause" sessionKey="Error" type="DOMDOC" />
                 <Param name="code" value="TechnicalError" /> 
-                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
-                <Param name="detailsXml" type="DOMDOC"/>
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" ignoreUnresolvablePatternElements="true" />
+                <Param name="detailsXml" type="DOMDOC" />
                 <Forward name="success" path="EXCEPTION" />
                 <Forward name="exception" path="EXCEPTION" />
             </XsltPipe>

--- a/src/main/configurations/Translate/Configuration_ActualiseerZaakStatus.xml
+++ b/src/main/configurations/Translate/Configuration_ActualiseerZaakStatus.xml
@@ -26,7 +26,7 @@
                 <Param name="object" xpathExpression="$originalMessage/zakLk01/object[2]" type="DOMDOC">
                     <Param name="originalMessage" sessionKey="originalMessage" type="DOMDOC"/>
                 </Param>
-                <Forward name="success" path="CallGetZgwZaak" />
+                <Forward name="success" path="StoreZaakIdentificatie" />
             </PutInSessionPipe>
 
             <PutInSessionPipe 
@@ -34,6 +34,12 @@
                 <Param name="object" xpathExpression="$originalMessage/zakLk01/object[1]" type="DOMDOC">
                     <Param name="originalMessage" sessionKey="originalMessage" type="DOMDOC"/>
                 </Param>
+                <Forward name="success" path="StoreZaakIdentificatie" />
+            </PutInSessionPipe>
+
+            <PutInSessionPipe 
+                name="StoreZaakIdentificatie">
+                <Param name="Identificatie" sessionKey="object" xpathExpression="object/identificatie"/>
                 <Forward name="success" path="CallGetZgwZaak" />
             </PutInSessionPipe>
             
@@ -45,11 +51,31 @@
                     name="CallGetZgwZaakSender"
                     javaListener="GetZgwZaak"
                     returnedSessionKeys="Error">
-                    <Param name="Identificatie" sessionKey="object" xpathExpression="object/identificatie"/>
+                    <Param name="Identificatie" sessionKey="Identificatie"/>
                 </IbisLocalSender>
-                <Forward name="success" path="CallGetZaakTypeByZaak"/>
+                <Forward name="success" path="CheckForGetZgwZaakResult"/>
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
+
+            <XmlIfPipe name="CheckForGetZgwZaakResult"
+                xpathExpression="string-length(ZgwZaken) > 0"
+                >
+                <Forward name="then" path="CallGetZaakTypeByZaak"/>
+                <Forward name="else" path="BuildErrorMessage"/>
+            </XmlIfPipe>
+
+            <XsltPipe
+                name="BuildErrorMessage"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> 
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
+                <Param name="detailsXml" type="DOMDOC"/>
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <SenderPipe
                 name="CallGetZaakTypeByZaak"

--- a/src/main/configurations/Translate/Configuration_AndereZaak.xml
+++ b/src/main/configurations/Translate/Configuration_AndereZaak.xml
@@ -23,9 +23,29 @@
                     returnedSessionKeys="Error">
                     <Param name="Identificatie" sessionKey="Identificatie"/>
                 </IbisLocalSender>
-                <Forward name="success" path="GetSingleZgwAndereZaakFromZgwZakenList"/>
+                <Forward name="success" path="CheckForGetZgwZaakResult"/>
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
+
+            <XmlIfPipe name="CheckForGetZgwZaakResult"
+                xpathExpression="string-length(ZgwZaken) > 0"
+                >
+                <Forward name="then" path="GetSingleZgwAndereZaakFromZgwZakenList"/>
+                <Forward name="else" path="BuildErrorMessage"/>
+            </XmlIfPipe>
+
+            <XsltPipe
+                name="BuildErrorMessage"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> 
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
+                <Param name="detailsXml" type="DOMDOC"/>
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <XsltPipe
                 name="GetSingleZgwAndereZaakFromZgwZakenList"

--- a/src/main/configurations/Translate/Configuration_AndereZaak.xml
+++ b/src/main/configurations/Translate/Configuration_AndereZaak.xml
@@ -23,26 +23,28 @@
                     returnedSessionKeys="Error">
                     <Param name="Identificatie" sessionKey="Identificatie"/>
                 </IbisLocalSender>
-                <Forward name="success" path="CheckForGetZgwZaakResult"/>
+                <Forward name="success" path="ZaakNotFound_Condition"/>
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
 
-            <XmlIfPipe name="CheckForGetZgwZaakResult"
-                xpathExpression="string-length(ZgwZaken) > 0"
+            <XmlIfPipe
+                name="ZaakNotFound_Condition"
+                xpathExpression="string-length(ZgwZaken) = 0"
                 >
-                <Forward name="then" path="GetSingleZgwAndereZaakFromZgwZakenList"/>
-                <Forward name="else" path="BuildErrorMessage"/>
+                <Forward name="then" path="ZaakNotFound_Exception" />
+                <Forward name="else" path="GetSingleZgwAndereZaakFromZgwZakenList" />
             </XmlIfPipe>
 
             <XsltPipe
-                name="BuildErrorMessage"
+                name="ZaakNotFound_Exception"
                 getInputFromFixedValue="&lt;dummy/&gt;"
                 styleSheetName="Common/xsl/BuildError.xsl"
-                storeResultInSessionKey="Error">
+                storeResultInSessionKey="Error"
+                >
                 <Param name="cause" sessionKey="Error" type="DOMDOC" />
                 <Param name="code" value="TechnicalError" /> 
-                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
-                <Param name="detailsXml" type="DOMDOC"/>
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" ignoreUnresolvablePatternElements="true" />
+                <Param name="detailsXml" type="DOMDOC" />
                 <Forward name="success" path="EXCEPTION" />
                 <Forward name="exception" path="EXCEPTION" />
             </XsltPipe>

--- a/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
@@ -22,9 +22,16 @@
                     returnedSessionKeys="Error">
                     <Param name="Identificatie" sessionKey="ZaakIdentificatie"/>
                 </IbisLocalSender>
-                <Forward name="success" path="CallGetZaakInformatieObjectenByZaak"/>
+                <Forward name="success" path="CheckForGetZgwZaakResult"/>
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
+
+            <XmlIfPipe name="CheckForGetZgwZaakResult"
+                xpathExpression="string-length(ZgwZaken) > 0"
+                >
+                <Forward name="then" path="CallGetZaakInformatieObjectenByZaak"/>
+                <Forward name="else" path="EXIT"/>
+            </XmlIfPipe>
 
             <SenderPipe
                 name="CallGetZaakInformatieObjectenByZaak"

--- a/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
@@ -22,15 +22,16 @@
                     returnedSessionKeys="Error">
                     <Param name="Identificatie" sessionKey="ZaakIdentificatie"/>
                 </IbisLocalSender>
-                <Forward name="success" path="CheckForGetZgwZaakResult"/>
+                <Forward name="success" path="ZaakNotFound_Condition" />
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
 
-            <XmlIfPipe name="CheckForGetZgwZaakResult"
-                xpathExpression="string-length(ZgwZaken) > 0"
+            <XmlIfPipe
+                name="ZaakNotFound_Condition"
+                xpathExpression="string-length(ZgwZaken) = 0"
                 >
-                <Forward name="then" path="CallGetZaakInformatieObjectenByZaak"/>
-                <Forward name="else" path="EXIT"/>
+                <Forward name="then" path="EXIT" />
+                <Forward name="else" path="CallGetZaakInformatieObjectenByZaak" />
             </XmlIfPipe>
 
             <SenderPipe

--- a/src/main/configurations/Translate/Configuration_GeefZaakdetails_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_GeefZaakdetails_Lv01.xml
@@ -31,15 +31,16 @@
                     returnedSessionKeys="Error">
                     <Param name="Identificatie" xpathExpression="zakLv01/gelijk/identificatie"/>
                 </IbisLocalSender>
-                <Forward name="success" path="CheckForGetZgwZaakResult"/>
+                <Forward name="success" path="ZaakNotFound_Condition" />
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
             
-            <XmlIfPipe name="CheckForGetZgwZaakResult"
-                xpathExpression="string-length(ZgwZaken) > 0"
+            <XmlIfPipe
+                name="ZaakNotFound_Condition"
+                xpathExpression="string-length(ZgwZaken) = 0"
                 >
-                <Forward name="then" path="GetSingleZgwZaakFromZgwZakenList"/>
-                <Forward name="else" path="EXIT"/>
+                <Forward name="then" path="EXIT" />
+                <Forward name="else" path="GetSingleZgwZaakFromZgwZakenList" />
             </XmlIfPipe>
         
             <XsltPipe

--- a/src/main/configurations/Translate/Configuration_GeefZaakdetails_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_GeefZaakdetails_Lv01.xml
@@ -39,7 +39,7 @@
                 xpathExpression="string-length(ZgwZaken) > 0"
                 >
                 <Forward name="then" path="GetSingleZgwZaakFromZgwZakenList"/>
-                <Forward name="else" path="EXCEPTION"/>
+                <Forward name="else" path="EXIT"/>
             </XmlIfPipe>
         
             <XsltPipe

--- a/src/main/configurations/Translate/Configuration_GetZaakDetailsByRol.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDetailsByRol.xml
@@ -56,9 +56,15 @@
                         <Param name="ZgwRol" sessionKey="originalMessage" type="DOMDOC"/>
                     </Param>
                 </IbisLocalSender>
-                <Forward name="success" path="CallGetZgwZaak"/>
+                <Forward name="success" path="StoreZaakIdentificatie"/>
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
+
+            <PutInSessionPipe 
+                name="StoreZaakIdentificatie">
+                <Param name="Identificatie" xpathExpression="/ZgwZaak/identificatie"/>
+                <Forward name="success" path="CallGetZgwZaak" />
+            </PutInSessionPipe>
 
             <SenderPipe
                 name="CallGetZgwZaak"
@@ -67,7 +73,7 @@
                     name="CallGetZgwZaakSender"
                     javaListener="GetZgwZaak"
                     returnedSessionKeys="Error">
-                    <Param name="Identificatie" xpathExpression="/ZgwZaak/identificatie"/>
+                    <Param name="Identificatie" sessionKey="Identificatie"/>
                 </IbisLocalSender>
                 <Forward name="success" path="CheckForGetZgwZaakResult"/>
                 <Forward name="exception" path="EXCEPTION" />
@@ -77,8 +83,21 @@
                 xpathExpression="string-length(ZgwZaken) > 0"
                 >
                 <Forward name="then" path="GetSingleZgwZaakFromZgwZakenList"/>
-                <Forward name="else" path="EXCEPTION"/>
+                <Forward name="else" path="BuildErrorMessage"/>
             </XmlIfPipe>
+
+            <XsltPipe
+                name="BuildErrorMessage"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> 
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
+                <Param name="detailsXml" type="DOMDOC"/>
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
         
             <XsltPipe
                 name="GetSingleZgwZaakFromZgwZakenList"

--- a/src/main/configurations/Translate/Configuration_GetZaakDetailsByRol.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDetailsByRol.xml
@@ -56,13 +56,14 @@
                         <Param name="ZgwRol" sessionKey="originalMessage" type="DOMDOC"/>
                     </Param>
                 </IbisLocalSender>
-                <Forward name="success" path="StoreZaakIdentificatie"/>
+                <Forward name="success" path="StoreZaakIdentificatie" />
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
 
             <PutInSessionPipe 
-                name="StoreZaakIdentificatie">
-                <Param name="Identificatie" xpathExpression="/ZgwZaak/identificatie"/>
+                name="StoreZaakIdentificatie"
+                >
+                <Param name="Identificatie" xpathExpression="/ZgwZaak/identificatie" />
                 <Forward name="success" path="CallGetZgwZaak" />
             </PutInSessionPipe>
 
@@ -73,28 +74,30 @@
                     name="CallGetZgwZaakSender"
                     javaListener="GetZgwZaak"
                     returnedSessionKeys="Error">
-                    <Param name="Identificatie" sessionKey="Identificatie"/>
+                    <Param name="Identificatie" sessionKey="Identificatie" />
                 </IbisLocalSender>
-                <Forward name="success" path="CheckForGetZgwZaakResult"/>
+                <Forward name="success" path="ZaakNotFound_Condition" />
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
             
-            <XmlIfPipe name="CheckForGetZgwZaakResult"
-                xpathExpression="string-length(ZgwZaken) > 0"
+            <XmlIfPipe
+                name="ZaakNotFound_Condition"
+                xpathExpression="string-length(ZgwZaken) = 0"
                 >
-                <Forward name="then" path="GetSingleZgwZaakFromZgwZakenList"/>
-                <Forward name="else" path="BuildErrorMessage"/>
+                <Forward name="then" path="ZaakNotFound_Exception" />
+                <Forward name="else" path="GetSingleZgwZaakFromZgwZakenList" />
             </XmlIfPipe>
 
             <XsltPipe
-                name="BuildErrorMessage"
+                name="ZaakNotFound_Exception"
                 getInputFromFixedValue="&lt;dummy/&gt;"
                 styleSheetName="Common/xsl/BuildError.xsl"
-                storeResultInSessionKey="Error">
+                storeResultInSessionKey="Error"
+                >
                 <Param name="cause" sessionKey="Error" type="DOMDOC" />
                 <Param name="code" value="TechnicalError" /> 
-                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
-                <Param name="detailsXml" type="DOMDOC"/>
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" ignoreUnresolvablePatternElements="true" />
+                <Param name="detailsXml" type="DOMDOC" />
                 <Forward name="success" path="EXCEPTION" />
                 <Forward name="exception" path="EXCEPTION" />
             </XsltPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -63,7 +63,7 @@
             </XsltPipe>
 
             <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList"/>
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList" />
             </JsonPipe>
 
             <XsltPipe

--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -63,26 +63,8 @@
             </XsltPipe>
 
             <JsonPipe name="JsonToXml">
-                <Forward name="success" path="checkCount"/>
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList"/>
             </JsonPipe>
-
-            <XmlIfPipe name="checkCount" xpathExpression="root/count = 0">
-                <Forward name="then" path="BuildErrorMessage" />
-                <Forward name="else" path="UnwrapOpenZaakApiEnvelopeToList" />
-            </XmlIfPipe>
-
-            <XsltPipe
-                name="BuildErrorMessage"
-                getInputFromFixedValue="&lt;dummy/&gt;"
-                styleSheetName="Common/xsl/BuildError.xsl"
-                storeResultInSessionKey="Error">
-                <Param name="cause" sessionKey="Error" type="DOMDOC" />
-                <Param name="code" value="TechnicalError" /> 
-                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaakByIdentificatie" />
-                <Param name="detailsXml" type="DOMDOC"/>
-                <Forward name="success" path="EXCEPTION" />
-                <Forward name="exception" path="EXCEPTION" />
-            </XsltPipe>
 
             <XsltPipe
                 name="UnwrapOpenZaakApiEnvelopeToList"

--- a/src/main/configurations/Translate/Configuration_SoapEndpointRouter_BeantwoordVraag.xml
+++ b/src/main/configurations/Translate/Configuration_SoapEndpointRouter_BeantwoordVraag.xml
@@ -133,9 +133,15 @@
                     javaListener="GeefZaakdetails_Lv01"
                     returnedSessionKeys="Error">
                 </IbisLocalSender>
-                <Forward name="success" path="ReplaceNulls" />
+                <Forward name="success" path="CheckGeefZaakDetailsResult" />
                 <Forward name="exception" path="BackEndError" />
             </SenderPipe>
+
+            <XmlIfPipe name="CheckGeefZaakDetailsResult" 
+                xpathExpression="string-length(/root) &gt; 0">
+                <Forward name="then" path="ReplaceNulls" />
+                <Forward name="else" path="WrapZakLa01Response" />
+            </XmlIfPipe>
 
             <XsltPipe
                 name="ReplaceNulls"

--- a/src/main/configurations/Translate/Configuration_SoapEndpointRouter_BeantwoordVraag.xml
+++ b/src/main/configurations/Translate/Configuration_SoapEndpointRouter_BeantwoordVraag.xml
@@ -137,8 +137,10 @@
                 <Forward name="exception" path="BackEndError" />
             </SenderPipe>
 
-            <XmlIfPipe name="CheckGeefZaakDetailsResult" 
-                xpathExpression="string-length(/root) &gt; 0">
+            <XmlIfPipe
+                name="CheckGeefZaakDetailsResult" 
+                xpathExpression="string-length(/root) gt 0"
+                >
                 <Forward name="then" path="ReplaceNulls" />
                 <Forward name="else" path="WrapZakLa01Response" />
             </XmlIfPipe>

--- a/src/main/configurations/Translate/Configuration_UpdateZaak_LK01.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZaak_LK01.xml
@@ -14,8 +14,9 @@
             </Exits>
 
             <PutInSessionPipe 
-                name="StoreZaakIdentificatie">
-                <Param name="Identificatie" xpathExpression="/zakLk01/object[1]/identificatie"/>
+                name="StoreZaakIdentificatie"
+                >
+                <Param name="Identificatie" xpathExpression="/zakLk01/object[1]/identificatie" />
                 <Forward name="success" path="CallGetZgwZaak" />
             </PutInSessionPipe>
 
@@ -27,28 +28,30 @@
                     name="CallGetZgwZaakSender"
                     javaListener="GetZgwZaak"
                     returnedSessionKeys="Error">
-                    <Param name="Identificatie" sessionKey="Identificatie"/>
+                    <Param name="Identificatie" sessionKey="Identificatie" />
                 </IbisLocalSender>
-                <Forward name="success" path="CheckForGetZgwZaakResult"/>
+                <Forward name="success" path="ZaakNotFound_Condition" />
                 <Forward name="exception" path="UncaughtException" />
             </SenderPipe>
             
-            <XmlIfPipe name="CheckForGetZgwZaakResult"
-                xpathExpression="string-length(ZgwZaken) > 0"
+            <XmlIfPipe
+                name="ZaakNotFound_Condition"
+                xpathExpression="string-length(ZgwZaken) = 0"
                 >
-                <Forward name="then" path="GetSingleZgwZaakFromZgwZakenList"/>
-                <Forward name="else" path="BuildErrorMessage"/>
+                <Forward name="then" path="ZaakNotFound_Exception" />
+                <Forward name="else" path="GetSingleZgwZaakFromZgwZakenList" />
             </XmlIfPipe>
 
             <XsltPipe
-                name="BuildErrorMessage"
+                name="ZaakNotFound_Exception"
                 getInputFromFixedValue="&lt;dummy/&gt;"
                 styleSheetName="Common/xsl/BuildError.xsl"
-                storeResultInSessionKey="Error">
+                storeResultInSessionKey="Error"
+                >
                 <Param name="cause" sessionKey="Error" type="DOMDOC" />
                 <Param name="code" value="TechnicalError" /> 
-                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
-                <Param name="detailsXml" type="DOMDOC"/>
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" ignoreUnresolvablePatternElements="true" />
+                <Param name="detailsXml" type="DOMDOC" />
                 <Forward name="success" path="EXCEPTION" />
                 <Forward name="exception" path="EXCEPTION" />
             </XsltPipe>

--- a/src/main/configurations/Translate/Configuration_UpdateZaak_LK01.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZaak_LK01.xml
@@ -13,6 +13,12 @@
                 <Exit name="EXCEPTION" state="ERROR"/>
             </Exits>
 
+            <PutInSessionPipe 
+                name="StoreZaakIdentificatie">
+                <Param name="Identificatie" xpathExpression="/zakLk01/object[1]/identificatie"/>
+                <Forward name="success" path="CallGetZgwZaak" />
+            </PutInSessionPipe>
+
             <!-- Retrieve was zgwZaak -->
             <SenderPipe
                 name="CallGetZgwZaak"
@@ -21,7 +27,7 @@
                     name="CallGetZgwZaakSender"
                     javaListener="GetZgwZaak"
                     returnedSessionKeys="Error">
-                    <Param name="Identificatie" xpathExpression="/zakLk01/object[1]/identificatie"/>
+                    <Param name="Identificatie" sessionKey="Identificatie"/>
                 </IbisLocalSender>
                 <Forward name="success" path="CheckForGetZgwZaakResult"/>
                 <Forward name="exception" path="UncaughtException" />
@@ -31,8 +37,21 @@
                 xpathExpression="string-length(ZgwZaken) > 0"
                 >
                 <Forward name="then" path="GetSingleZgwZaakFromZgwZakenList"/>
-                <Forward name="else" path="UncaughtException"/>
+                <Forward name="else" path="BuildErrorMessage"/>
             </XmlIfPipe>
+
+            <XsltPipe
+                name="BuildErrorMessage"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> 
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
+                <Param name="detailsXml" type="DOMDOC"/>
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
         
             <XsltPipe
                 name="GetSingleZgwZaakFromZgwZakenList"

--- a/src/main/configurations/Translate/Configuration_VoegZaakdocumentToe_Lk01.xml
+++ b/src/main/configurations/Translate/Configuration_VoegZaakdocumentToe_Lk01.xml
@@ -24,8 +24,9 @@
 
             <PutInSessionPipe 
                 name="StoreZaakIdentificatie"
-                getInputFromSessionKey="ZdsZaakDocumentInhoud">
-                <Param name="Identificatie" xpathExpression="object/isRelevantVoor/gerelateerde/identificatie"/>
+                getInputFromSessionKey="ZdsZaakDocumentInhoud"
+                >
+                <Param name="Identificatie" xpathExpression="object/isRelevantVoor/gerelateerde/identificatie" />
                 <Forward name="success" path="CallGetZgwZaak" />
             </PutInSessionPipe>
 
@@ -35,27 +36,29 @@
                     name="CallGetZgwZaakSender"
                     javaListener="GetZgwZaak"
                     returnedSessionKeys="Error">
-                    <Param name="Identificatie" sessionKey="Identificatie"/>
+                    <Param name="Identificatie" sessionKey="Identificatie" />
                 </IbisLocalSender>
-                <Forward name="success" path="CheckForGetZgwZaakResult"/>
+                <Forward name="success" path="ZaakNotFound_Condition" />
                 <Forward name="exception" path="UncaughtException" />
             </SenderPipe>
 
-            <XmlIfPipe name="CheckForGetZgwZaakResult"
-                xpathExpression="string-length(ZgwZaken) > 0"
+            <XmlIfPipe
+                name="ZaakNotFound_Condition"
+                xpathExpression="string-length(ZgwZaken) = 0"
                 >
-                <Forward name="then" path="GetSingleZgwZaakFromZgwZakenList"/>
-                <Forward name="else" path="BuildErrorMessage"/>
+                <Forward name="then" path="ZaakNotFound_Exception" />
+                <Forward name="else" path="GetSingleZgwZaakFromZgwZakenList" />
             </XmlIfPipe>
 
             <XsltPipe
-                name="BuildErrorMessage"
+                name="ZaakNotFound_Exception"
                 getInputFromFixedValue="&lt;dummy/&gt;"
                 styleSheetName="Common/xsl/BuildError.xsl"
-                storeResultInSessionKey="Error">
+                storeResultInSessionKey="Error"
+                >
                 <Param name="cause" sessionKey="Error" type="DOMDOC" />
                 <Param name="code" value="TechnicalError" /> 
-                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" ignoreUnresolvablePatternElements="true" />
                 <Param name="detailsXml" type="DOMDOC"/>
                 <Forward name="success" path="EXCEPTION" />
                 <Forward name="exception" path="EXCEPTION" />

--- a/src/main/configurations/Translate/Configuration_VoegZaakdocumentToe_Lk01.xml
+++ b/src/main/configurations/Translate/Configuration_VoegZaakdocumentToe_Lk01.xml
@@ -16,19 +16,26 @@
             <PutInSessionPipe 
                 name="StoreZdsZaakDocumentInhoud">
                 <Param name="ZdsZaakDocumentInhoud" xpathExpression="edcLk01/object[1]" type="DOMDOC"/>
-                <Forward name="success" path="CallGetZgwZaak" />
+                <Forward name="success" path="StoreZaakIdentificatie" />
             </PutInSessionPipe>
             <!-- <EchoPipe name="StoreDocumentData" elementToMove="inhoud" getInputFromSessionKey="ZdsZaakDocumentInhoud" storeResultInSessionKey="ZdsZaakDocumentInhoudDataRef">
                 <Forward name="success" path="CallGetZgwZaak" />
             </EchoPipe> -->
-            <SenderPipe
-                name="CallGetZgwZaak"
+
+            <PutInSessionPipe 
+                name="StoreZaakIdentificatie"
                 getInputFromSessionKey="ZdsZaakDocumentInhoud">
+                <Param name="Identificatie" xpathExpression="object/isRelevantVoor/gerelateerde/identificatie"/>
+                <Forward name="success" path="CallGetZgwZaak" />
+            </PutInSessionPipe>
+
+            <SenderPipe
+                name="CallGetZgwZaak">
                 <IbisLocalSender
                     name="CallGetZgwZaakSender"
                     javaListener="GetZgwZaak"
                     returnedSessionKeys="Error">
-                    <Param name="Identificatie" xpathExpression="object/isRelevantVoor/gerelateerde/identificatie"/>
+                    <Param name="Identificatie" sessionKey="Identificatie"/>
                 </IbisLocalSender>
                 <Forward name="success" path="CheckForGetZgwZaakResult"/>
                 <Forward name="exception" path="UncaughtException" />
@@ -38,8 +45,21 @@
                 xpathExpression="string-length(ZgwZaken) > 0"
                 >
                 <Forward name="then" path="GetSingleZgwZaakFromZgwZakenList"/>
-                <Forward name="else" path="UncaughtException"/>
+                <Forward name="else" path="BuildErrorMessage"/>
             </XmlIfPipe>
+
+            <XsltPipe
+                name="BuildErrorMessage"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> 
+                <Param name="reason" pattern="No zaak with the identificatie:{Identificatie} is found in GetZgwZaak" />
+                <Param name="detailsXml" type="DOMDOC"/>
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
         
             <XsltPipe
                 name="GetSingleZgwZaakFromZgwZakenList"


### PR DESCRIPTION
The adapters geefLijstZaakdocumenten and geefZaakDetails have this pipe which is retrieving the zaak that is requested. 

If the zaak is not found then we were returning an error message mentioning 'no zaak is found with this {identificatie}'. 

Now, instead of returning error we return empty object element with attributes StUF:entiteittype="ZAK" StUF:noValue="waardeOnbekend" inside antwoord element.