### PR TITLE
fix: defaultProfile not being used when there is no zaaktype specific translation profile configured

### DIFF
--- a/src/main/configurations/Translate/Common/xsl/ExtractValueOverridesFromTranslationProfile.xsl
+++ b/src/main/configurations/Translate/Common/xsl/ExtractValueOverridesFromTranslationProfile.xsl
@@ -4,11 +4,19 @@
 
     <xsl:template match="/">
         <root>
-            <xsl:apply-templates select="//profile[zaakTypeIdentificatie = $zaaktype]" />
+            <!-- Check for profile with matching zaakTypeIdentificatie -->
+            <xsl:choose>
+                <xsl:when test="//profile[zaakTypeIdentificatie = $zaaktype]">
+                    <xsl:apply-templates select="//profile[zaakTypeIdentificatie = $zaaktype]/valueOverrides" mode="copy"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="//profileDefaults/valueOverrides" mode="copy"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </root>
     </xsl:template>
 
-    <xsl:template match="profile">
-        <xsl:copy-of select="valueOverrides" />
+    <xsl:template match="valueOverrides" mode="copy">
+        <xsl:copy-of select="." />
     </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/MergeProfileDefaultsWithProfiles-orig.js
+++ b/src/main/resources/MergeProfileDefaultsWithProfiles-orig.js
@@ -7,7 +7,7 @@ function mergeProfileDefaultsWithProfiles(profilesFile){
     result["profile"] = [];
     result["profileDefaults"] = json["profileDefaults"];
 
-    if(json["profileDefaults"] == null || json["profile"] == null){
+    if(json["profileDefaults"] == null || json["profile"] == null || Object.keys(json["profileDefaults"]).length === 0){
         return profilesFile;
     }
 
@@ -18,15 +18,16 @@ function mergeProfileDefaultsWithProfiles(profilesFile){
         Object.keys(pf)
         .forEach(key => pfres[key] = pf[key]);
 
-        if(pf["valueOverrides"] == null){
+        if(pf["valueOverrides"] == null || profileDefaults.profile["valueOverrides"] == null){
             result.profile.push(pfres);
             continue;
         }
 
-        pfres["valueOverrides"] = pf.valueOverrides
-            .concat(profileDefaults.profile.valueOverrides
-                    .filter((value) => pf.valueOverrides
-                        .find((value2) => value2.key != value.key)));
+        pfres["valueOverrides"] = (profileDefaults.profile.valueOverrides)
+            .map(({ key, value }) => ({
+                key,
+                value: pf.valueOverrides.find(obj => obj.key === key)?.value ?? value
+            }));
 
         result.profile.push(pfres);
     }

--- a/src/main/resources/MergeProfileDefaultsWithProfiles-orig.js
+++ b/src/main/resources/MergeProfileDefaultsWithProfiles-orig.js
@@ -1,29 +1,29 @@
 function mergeProfileDefaultsWithProfiles(profilesFile){
     const json = JSON.parse(profilesFile);
-    const profileDefaults = {"profile": json["profileDefaults"]};
-    const profiles = { "profile": json["profile"] };
+    const profileDefaults = json["profileDefaults"];
+    const profiles = json["profile"];
 
     let result = {};
     result["profile"] = [];
-    result["profileDefaults"] = json["profileDefaults"];
+    result["profileDefaults"] = profileDefaults;
 
-    if(json["profileDefaults"] == null || json["profile"] == null || Object.keys(json["profileDefaults"]).length === 0){
+    if(profileDefaults == null || profiles == null || Object.keys(profileDefaults).length === 0){
         return profilesFile;
     }
 
-    for(const pf of profiles.profile){
+    for(const pf of profiles){
         let pfres = {};
-        Object.keys(profileDefaults.profile)
-        .forEach(key => pfres[key] = profileDefaults.profile[key]);
+        Object.keys(profileDefaults)
+        .forEach(key => pfres[key] = profileDefaults[key]);
         Object.keys(pf)
         .forEach(key => pfres[key] = pf[key]);
 
-        if(pf["valueOverrides"] == null || profileDefaults.profile["valueOverrides"] == null){
+        if(pf["valueOverrides"] == null || profileDefaults["valueOverrides"] == null){
             result.profile.push(pfres);
             continue;
         }
 
-        pfres["valueOverrides"] = (profileDefaults.profile.valueOverrides)
+        pfres["valueOverrides"] = (profileDefaults.valueOverrides)
             .map(({ key, value }) => ({
                 key,
                 value: pf.valueOverrides.find(obj => obj.key === key)?.value ?? value

--- a/src/main/resources/MergeProfileDefaultsWithProfiles-orig.js
+++ b/src/main/resources/MergeProfileDefaultsWithProfiles-orig.js
@@ -23,11 +23,11 @@ function mergeProfileDefaultsWithProfiles(profilesFile){
             continue;
         }
 
-        pfres["valueOverrides"] = (profileDefaults.valueOverrides)
-            .map(({ key, value }) => ({
-                key,
-                value: pf.valueOverrides.find(obj => obj.key === key)?.value ?? value
-            }));
+        pfres["valueOverrides"] = [
+            ...pf.valueOverrides,
+            ...profileDefaults.valueOverrides.filter(({key}) => !pf.valueOverrides.some(obj => obj.key === key)
+            )
+        ];
 
         result.profile.push(pfres);
     }

--- a/src/main/resources/MergeProfileDefaultsWithProfiles.js
+++ b/src/main/resources/MergeProfileDefaultsWithProfiles.js
@@ -1,5 +1,9 @@
 "use strict";
 
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
@@ -29,17 +33,12 @@ function mergeProfileDefaultsWithProfiles(profilesFile) {
         result.profile.push(pfres);
         return "continue";
       }
-      pfres["valueOverrides"] = profileDefaults.valueOverrides.map(function (_ref) {
-        var _pf$valueOverrides$fi, _pf$valueOverrides$fi2;
-        var key = _ref.key,
-          value = _ref.value;
-        return {
-          key: key,
-          value: (_pf$valueOverrides$fi = (_pf$valueOverrides$fi2 = pf.valueOverrides.find(function (obj) {
-            return obj.key === key;
-          })) === null || _pf$valueOverrides$fi2 === void 0 ? void 0 : _pf$valueOverrides$fi2.value) !== null && _pf$valueOverrides$fi !== void 0 ? _pf$valueOverrides$fi : value
-        };
-      });
+      pfres["valueOverrides"] = [].concat(_toConsumableArray(pf.valueOverrides), _toConsumableArray(profileDefaults.valueOverrides.filter(function (_ref) {
+        var key = _ref.key;
+        return !pf.valueOverrides.some(function (obj) {
+          return obj.key === key;
+        });
+      })));
       result.profile.push(pfres);
     };
     for (_iterator.s(); !(_step = _iterator.n()).done;) {

--- a/src/main/resources/MergeProfileDefaultsWithProfiles.js
+++ b/src/main/resources/MergeProfileDefaultsWithProfiles.js
@@ -5,35 +5,31 @@ function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o =
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
 function mergeProfileDefaultsWithProfiles(profilesFile) {
   var json = JSON.parse(profilesFile);
-  var profileDefaults = {
-    "profile": json["profileDefaults"]
-  };
-  var profiles = {
-    "profile": json["profile"]
-  };
+  var profileDefaults = json["profileDefaults"];
+  var profiles = json["profile"];
   var result = {};
   result["profile"] = [];
-  result["profileDefaults"] = json["profileDefaults"];
-  if (json["profileDefaults"] == null || json["profile"] == null || Object.keys(json["profileDefaults"]).length === 0) {
+  result["profileDefaults"] = profileDefaults;
+  if (profileDefaults == null || profiles == null || Object.keys(profileDefaults).length === 0) {
     return profilesFile;
   }
-  var _iterator = _createForOfIteratorHelper(profiles.profile),
+  var _iterator = _createForOfIteratorHelper(profiles),
     _step;
   try {
     var _loop = function _loop() {
       var pf = _step.value;
       var pfres = {};
-      Object.keys(profileDefaults.profile).forEach(function (key) {
-        return pfres[key] = profileDefaults.profile[key];
+      Object.keys(profileDefaults).forEach(function (key) {
+        return pfres[key] = profileDefaults[key];
       });
       Object.keys(pf).forEach(function (key) {
         return pfres[key] = pf[key];
       });
-      if (pf["valueOverrides"] == null || profileDefaults.profile["valueOverrides"] == null) {
+      if (pf["valueOverrides"] == null || profileDefaults["valueOverrides"] == null) {
         result.profile.push(pfres);
         return "continue";
       }
-      pfres["valueOverrides"] = profileDefaults.profile.valueOverrides.map(function (_ref) {
+      pfres["valueOverrides"] = profileDefaults.valueOverrides.map(function (_ref) {
         var _pf$valueOverrides$fi, _pf$valueOverrides$fi2;
         var key = _ref.key,
           value = _ref.value;

--- a/src/main/resources/MergeProfileDefaultsWithProfiles.js
+++ b/src/main/resources/MergeProfileDefaultsWithProfiles.js
@@ -14,7 +14,7 @@ function mergeProfileDefaultsWithProfiles(profilesFile) {
   var result = {};
   result["profile"] = [];
   result["profileDefaults"] = json["profileDefaults"];
-  if (json["profileDefaults"] == null || json["profile"] == null) {
+  if (json["profileDefaults"] == null || json["profile"] == null || Object.keys(json["profileDefaults"]).length === 0) {
     return profilesFile;
   }
   var _iterator = _createForOfIteratorHelper(profiles.profile),
@@ -29,15 +29,21 @@ function mergeProfileDefaultsWithProfiles(profilesFile) {
       Object.keys(pf).forEach(function (key) {
         return pfres[key] = pf[key];
       });
-      if (pf["valueOverrides"] == null) {
+      if (pf["valueOverrides"] == null || profileDefaults.profile["valueOverrides"] == null) {
         result.profile.push(pfres);
         return "continue";
       }
-      pfres["valueOverrides"] = pf.valueOverrides.concat(profileDefaults.profile.valueOverrides.filter(function (value) {
-        return pf.valueOverrides.find(function (value2) {
-          return value2.key != value.key;
-        });
-      }));
+      pfres["valueOverrides"] = profileDefaults.profile.valueOverrides.map(function (_ref) {
+        var _pf$valueOverrides$fi, _pf$valueOverrides$fi2;
+        var key = _ref.key,
+          value = _ref.value;
+        return {
+          key: key,
+          value: (_pf$valueOverrides$fi = (_pf$valueOverrides$fi2 = pf.valueOverrides.find(function (obj) {
+            return obj.key === key;
+          })) === null || _pf$valueOverrides$fi2 === void 0 ? void 0 : _pf$valueOverrides$fi2.value) !== null && _pf$valueOverrides$fi !== void 0 ? _pf$valueOverrides$fi : value
+        };
+      });
       result.profile.push(pfres);
     };
     for (_iterator.s(); !(_step = _iterator.n()).done;) {


### PR DESCRIPTION
- Previously, if zaakType is not listed in Profile.json file then we didn't return any value for betalingsindicatie. Now, in this case, we use the default values in profileDefaults property in ProfileJson file.

- There was also a hidden bug which was duplicating valueOverrides property in case both one of the profile itself and profileDefaults have this valueOverrides property. Now, it's been also solved. The values in Profile property in Profile.json file has the priority over profileDefaults property. In case a profile doesn't have a property that profileDefaults has then the value from profileDefaults is being used.

- Some extra parts in the javascript file has been removed to simplify the code.