### PR TITLE
fix: updateZaak incorrectly distinguishes roles due to 'authentiek' dataloss in translation resulting in attempt to add as new role

### DIFF
--- a/e2e/SoapUI/zaakbrug-e2e-soapui-project.xml
+++ b/e2e/SoapUI/zaakbrug-e2e-soapui-project.xml
@@ -8201,7 +8201,7 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue('DocumentBa
       <ZKN:gerelateerde>
         <ZKN:natuurlijkPersoon StUF:entiteittype="NPS">
           <BG:inp.bsn>111111110</BG:inp.bsn>
-          <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+          <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
           <BG:geslachtsnaam>Precies</BG:geslachtsnaam>
           <BG:voorletters>P</BG:voorletters>
           <BG:voornamen>Pietje</BG:voornamen>
@@ -8214,7 +8214,7 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue('DocumentBa
       <ZKN:gerelateerde>
         <ZKN:natuurlijkPersoon StUF:entiteittype="NPS">
           <BG:inp.bsn>111111110</BG:inp.bsn>
-          <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+          <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
           <BG:geslachtsnaam>Precies</BG:geslachtsnaam>
           <BG:voorletters>P</BG:voorletters>
           <BG:voornamen>Pietje</BG:voornamen>
@@ -8227,7 +8227,7 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue('DocumentBa
       <ZKN:gerelateerde>
         <ZKN:natuurlijkPersoon StUF:entiteittype="NPS">
           <BG:inp.bsn>111111110</BG:inp.bsn>
-          <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+          <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
           <BG:geslachtsnaam>Precies</BG:geslachtsnaam>
           <BG:voorletters>P</BG:voorletters>
           <BG:voornamen>Pietje</BG:voornamen>
@@ -18117,7 +18117,7 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue( 'JwtToken'
       <ZKN:gerelateerde>
         <ZKN:nietNatuurlijkPersoon StUF:entiteittype="NNP">
           <BG:inn.nnpId>823288444</BG:inn.nnpId>
-          <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+          <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
           <BG:statutaireNaam>Gemeente Súdwest-Fryslân</BG:statutaireNaam>
           <BG:inn.rechtsvorm>overig_privaatrechtelijke_rechtspersoon</BG:inn.rechtsvorm>
         </ZKN:nietNatuurlijkPersoon>
@@ -28972,7 +28972,7 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue('DocumentBa
       <ZKN:gerelateerde>
         <ZKN:natuurlijkPersoon StUF:entiteittype="NPS">
           <BG:inp.bsn>111111110</BG:inp.bsn>
-          <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+          <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
           <BG:geslachtsnaam>Precies</BG:geslachtsnaam>
           <BG:voorletters>P</BG:voorletters>
           <BG:voornamen>Pietje</BG:voornamen>
@@ -29098,7 +29098,7 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue('DocumentBa
       <ZKN:gerelateerde>
         <ZKN:natuurlijkPersoon StUF:entiteittype="NPS">
           <BG:inp.bsn>111111110</BG:inp.bsn>
-          <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+          <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
           <BG:geslachtsnaam>Precies</BG:geslachtsnaam>
           <BG:voorletters>P</BG:voorletters>
           <BG:voornamen>Pietje</BG:voornamen>

--- a/e2e/SoapUI/zaakbrug-e2e-soapui-project.xml
+++ b/e2e/SoapUI/zaakbrug-e2e-soapui-project.xml
@@ -15306,7 +15306,7 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue( 'JwtToken'
       <ZKN:gerelateerde>
         <ZKN:natuurlijkPersoon StUF:entiteittype="NPS">
           <BG:inp.bsn>111111110</BG:inp.bsn>
-          <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+          <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
           <BG:geslachtsnaam>Precies</BG:geslachtsnaam>
           <BG:voorletters>P.J.</BG:voorletters>
           <BG:voornamen>Piet Je</BG:voornamen>
@@ -16715,7 +16715,7 @@ testRunner.testCase.getTestStepByName("Properties").setPropertyValue( 'JwtToken'
       <ZKN:gerelateerde>
         <ZKN:nietNatuurlijkPersoon StUF:entiteittype="NNP">
           <BG:inn.nnpId>823288444</BG:inn.nnpId>
-          <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+          <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
           <BG:statutaireNaam>Gemeente Súdwest-Fryslân</BG:statutaireNaam>
           <BG:inn.rechtsvorm>overig_privaatrechtelijke_rechtspersoon</BG:inn.rechtsvorm>
         </ZKN:nietNatuurlijkPersoon>

--- a/src/main/configurations/Translate/Common/xsl/CreateZakLa01Response.xslt
+++ b/src/main/configurations/Translate/Common/xsl/CreateZakLa01Response.xslt
@@ -199,7 +199,7 @@
                     <BG:inp.bsn><xsl:value-of select="inp.bsn"/></BG:inp.bsn>
                 </xsl:if>
                 <xsl:if test="authentiek">
-                    <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+                    <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
                 </xsl:if>
                 <xsl:if test="geslachtsnaam">
                     <BG:geslachtsnaam><xsl:value-of select="geslachtsnaam"/></BG:geslachtsnaam>
@@ -231,7 +231,7 @@
                     <BG:inn.nnpId><xsl:value-of select="inn.nnpId"/></BG:inn.nnpId>
                 </xsl:if>
                 <xsl:if test="authentiek">
-                    <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+                    <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
                 </xsl:if>
                 <xsl:if test="ann.identificatie">
                     <BG:ann.identificatie><xsl:value-of select="ann.identificatie"/></BG:ann.identificatie>

--- a/src/main/configurations/Translate/CreeerZaak_LK01/xsl/MapZdsRolFromZgwRol.xslt
+++ b/src/main/configurations/Translate/CreeerZaak_LK01/xsl/MapZdsRolFromZgwRol.xslt
@@ -21,7 +21,7 @@
             <gerelateerde>
                 <natuurlijkPersoon entiteittype="NPS">
                     <inp.bsn><xsl:value-of select="betrokkeneIdentificatie/inpBsn"/></inp.bsn>
-                    <authentiek>J</authentiek>
+                    <authentiek>N</authentiek>
                     <geslachtsnaam><xsl:value-of select="betrokkeneIdentificatie/geslachtsnaam"/></geslachtsnaam>
                     <voorvoegselGeslachtsnaam><xsl:value-of select="betrokkeneIdentificatie/voorvoegselGeslachtsnaam"/></voorvoegselGeslachtsnaam>
                     <voorletters><xsl:value-of select="betrokkeneIdentificatie/voorletters"/></voorletters>
@@ -40,7 +40,7 @@
             <gerelateerde>
                 <nietNatuurlijkPersoon entiteittype="NNP">
                     <inn.nnpId><xsl:value-of select="betrokkeneIdentificatie/innNnpId"/></inn.nnpId>
-                    <authentiek>J</authentiek>
+                    <authentiek>N</authentiek>
                     <ann.identificatie><xsl:value-of select="betrokkeneIdentificatie/annIdentificatie"/></ann.identificatie>
                     <statutaireNaam><xsl:value-of select="betrokkeneIdentificatie/statutaireNaam"/></statutaireNaam>
                     <inn.rechtsvorm><xsl:value-of select="betrokkeneIdentificatie/innRechtsvorm"/></inn.rechtsvorm>

--- a/src/main/configurations/Translate/UpdateZaak_LK01/xsl/CheckZgwRol.xslt
+++ b/src/main/configurations/Translate/UpdateZaak_LK01/xsl/CheckZgwRol.xslt
@@ -32,8 +32,9 @@
                         <xsl:variable name="currentName" select="local-name()"/>
                         <xsl:variable name="correspondingElement" select="$check/*[local-name() = $currentName]"/>
                         <xsl:choose>
+                        <xsl:when test="$currentName = 'authentiek'"/> <!--Do not compare 'Authentiek' field-->
                         <xsl:when test="not($correspondingElement)">
-                            <xsl:if test="not(@nil = 'true' or @noValue = 'geenWaarde' or . = '' or $currentName = 'authentiek')">
+                            <xsl:if test="not(@nil = 'true' or @noValue = 'geenWaarde' or . = '')">
                                 <xsl:copy-of select="false()"/>
                             </xsl:if>
                         </xsl:when>

--- a/src/main/configurations/Translate/UpdateZaak_LK01/xsl/CheckZgwRol.xslt
+++ b/src/main/configurations/Translate/UpdateZaak_LK01/xsl/CheckZgwRol.xslt
@@ -34,7 +34,7 @@
                         <xsl:choose>
                         <xsl:when test="$currentName = 'authentiek'"/> <!--Do not compare 'Authentiek' field-->
                         <xsl:when test="not($correspondingElement)">
-                            <xsl:if test="not(@nil = 'true' or @noValue = 'geenWaarde' or . = '')">
+                            <xsl:if test=". != ''">
                                 <xsl:copy-of select="false()"/>
                             </xsl:if>
                         </xsl:when>


### PR DESCRIPTION
- 'Authentiek' field is not represented in Openzaak so we are mapping this field statically with the value 'J' from Zgw to Zds. 
- In case this field has the value 'N' in updateZaak message in one of the role elements then the comparison fails and we interpret it as a different role while it is the same role and we try to add the same role again and we get error because the rol already exists in Openzaak.
- Because this field is not represented in Openzaak and mapped statically from zgw to zds by us, we are now skipping to compare this field while comparing two roles to see if they are the same roles.