### PR TITLE
fix: zaak 'heeft.indicatieLaatsteStatus' incorrectly uses zgw 'statustype.isEindstatus' instead of 'status.indicatieLaatstGezetteStatus'

### DIFF
--- a/src/main/configurations/Translate/Configuration_VoegZaakdocumentToe_Lk01.xml
+++ b/src/main/configurations/Translate/Configuration_VoegZaakdocumentToe_Lk01.xml
@@ -313,7 +313,7 @@
                 >
                 <Param name="ZgwZaak" sessionKey="ZgwZaak" type="DOMDOC"/>
                 <Param name="ZgwStatusType" sessionKey="ZgwStatusType" type="DOMDOC"/>
-                <Param name="ZdsStatusDatum" xpathExpression="concat(object/isRelevantVoor/sta.datumStatusGezet,'000000')"/>
+                <Param name="ZdsStatusDatum" xpathExpression="object/isRelevantVoor/sta.datumStatusGezet"/>
                 <Forward name="success" path="PostZgwStatusSender"/>
             </XsltPipe>
 

--- a/src/main/configurations/Translate/CreeerZaak_LK01/xsl/CreateZdsHeeft.xslt
+++ b/src/main/configurations/Translate/CreeerZaak_LK01/xsl/CreateZdsHeeft.xslt
@@ -50,7 +50,7 @@
                 </xsl:choose>
                 <xsl:choose>
                     <xsl:when test="$ZgwStatusType">
-                        <indicatieLaatsteStatus><xsl:value-of select="zgw:convertZgwBooleanToZdsBoolean($ZgwStatusType/root/ZgwStatusType/isEindstatus)"/></indicatieLaatsteStatus>
+                        <indicatieLaatsteStatus><xsl:value-of select="zgw:convertZgwBooleanToZdsBoolean($ZgwStatus/ZgwStatus/indicatieLaatstGezetteStatus)"/></indicatieLaatsteStatus>
                     </xsl:when>
                     <xsl:otherwise>
                         <indicatieLaatsteStatus><xsl:value-of select="$IndicatieLaatsteStatus"/></indicatieLaatsteStatus>

--- a/src/main/configurations/Translate/Zgw/Zaken/Model/ZgwStatus.xslt
+++ b/src/main/configurations/Translate/Zgw/Zaken/Model/ZgwStatus.xslt
@@ -25,10 +25,12 @@
             and (string-length($ZdsEinddatum) > 0) 
             and (string-length($ZdsStatusDatum) = 0) 
             and not($ZdsEinddatum = 'Undefined')">
-                <xsl:value-of select="zgw:toZgwDatetime(concat($ZdsEinddatum,'000000'))"/>
+                <!-- No guarantee that current time is later than statusDatumGezet of last set status if einddatum is in the past -->
+                <xsl:value-of select="zgw:toZgwDatetime(concat($ZdsEinddatum, zgw:currentZdsTime()))" />
             </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="zgw:toZgwDatetime($ZdsStatusDatum)"/>
+                <!-- No guarantee that current time is later than statusDatumGezet of last set status if einddatum is in the past -->
+                <xsl:value-of select="zgw:toZgwDatetime(concat($ZdsStatusDatum, zgw:currentZdsTime()))" />
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>

--- a/src/main/configurations/Translate/Zgw/ZgwFunctionsBase.xslt
+++ b/src/main/configurations/Translate/Zgw/ZgwFunctionsBase.xslt
@@ -260,4 +260,32 @@
         </xsl:choose>
     </xsl:function>
 
+    <xsl:function name="zgw:currentZdsDateTime" as="xs:string">
+        <xsl:variable name="currentUtcDateTime" select="adjust-dateTime-to-timezone(current-dateTime(), xs:dayTimeDuration('PT0H'))" />
+        <xsl:variable name="timezoneOffset" select="format-dateTime($currentUtcDateTime, '[Z]', (), (), environment-variable('zaakbrug.zds.timezone'))" />
+        <xsl:variable name="dayTimeDuration" as="xs:dayTimeDuration">
+            <xsl:choose>
+                <xsl:when test="starts-with($timezoneOffset, '+')">
+                    <xsl:value-of select="concat('PT', substring-before(substring-after($timezoneOffset, '+'), ':'), 'H')" />
+                </xsl:when>
+                <xsl:when test="starts-with($timezoneOffset, '-')">
+                    <xsl:value-of select="concat('PT-', substring-before(substring-after($timezoneOffset, '-'), ':'), 'H')" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="'PT0H'"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:variable name="adjustedDateTime" select="adjust-dateTime-to-timezone($currentUtcDateTime, $dayTimeDuration)" />
+        <xsl:value-of select="format-dateTime($adjustedDateTime, '[Y0001][M01][D01][H01][m01][s01]')" />
+    </xsl:function>
+
+    <xsl:function name="zgw:currentZdsDate" as="xs:string">
+        <xsl:value-of select="substring(zgw:currentZdsDateTime(), 1, 8)" />
+    </xsl:function>
+
+    <xsl:function name="zgw:currentZdsTime" as="xs:string">
+        <xsl:value-of select="substring(zgw:currentZdsDateTime(), 9, 6)" />
+    </xsl:function>
+
 </xsl:stylesheet>


### PR DESCRIPTION
heeft.indicatieLaatsteStatus was set with isEindStatus field of zgwStatustype but heeft.indicatieLaatsteStatus shouldn't show if the status is eindStatus but it should show if the status is the last set status so it doesn't have to be eindStatus to show the value "J". 
Now the mapping is done by using the zgwStatus's indicatieLaatstGezetteStatus field.