### PR TITLE
Save the field 'authentiek' in open zaak

### DIFF
--- a/src/main/configurations/Translate/Common/xsl/ZgwRol.xslt
+++ b/src/main/configurations/Translate/Common/xsl/ZgwRol.xslt
@@ -43,10 +43,19 @@
 
     <xsl:template match="*/*:gerelateerde/*:natuurlijkPersoon[@*:entiteittype='NPS']">
         <betrokkeneType>natuurlijk_persoon</betrokkeneType>
-        <roltoelichting><xsl:value-of select="concat($ZgwRolTypeOmschrijving, ':', geslachtsnaam)"/></roltoelichting>
+        <roltoelichting>
+            <xsl:choose>
+                <xsl:when test="authentiek != ''">
+                    <xsl:value-of select="concat($ZgwRolTypeOmschrijving, ':', geslachtsnaam, ', {# authentiek:', authentiek, ' #}')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="concat($ZgwRolTypeOmschrijving, ':', geslachtsnaam)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </roltoelichting>
         <betrokkeneIdentificatie>
             <xsl:if test="inp.bsn != ''"><inpBsn><xsl:value-of select="inp.bsn"/></inpBsn></xsl:if>
-            <xsl:if test="authentiek != ''"><authentiek><xsl:value-of select="authentiek"/></authentiek></xsl:if>
+            <xsl:if test="anp.identificatie != ''"><anpIdentificatie><xsl:value-of select="anp.identificatie"/></anpIdentificatie></xsl:if>
             <xsl:if test="geslachtsnaam != ''"><geslachtsnaam><xsl:value-of select="geslachtsnaam"/></geslachtsnaam></xsl:if>
             <xsl:if test="voorvoegselGeslachtsnaam != ''"><voorvoegselGeslachtsnaam><xsl:value-of select="voorvoegselGeslachtsnaam"/></voorvoegselGeslachtsnaam></xsl:if>
             <xsl:if test="voorletters != ''"><voorletters><xsl:value-of select="voorletters"/></voorletters></xsl:if>
@@ -61,10 +70,18 @@
 
     <xsl:template match="*/*:gerelateerde/*:nietNatuurlijkPersoon[@*:entiteittype='NNP']">
         <betrokkeneType>niet_natuurlijk_persoon</betrokkeneType>
-        <roltoelichting><xsl:value-of select="concat($ZgwRolTypeOmschrijving, ':', statutaireNaam)"/></roltoelichting>
+        <roltoelichting>
+            <xsl:choose>
+                <xsl:when test="authentiek != ''">
+                    <xsl:value-of select="concat($ZgwRolTypeOmschrijving, ':', statutaireNaam, ', {# authentiek:', authentiek, ' #}')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="concat($ZgwRolTypeOmschrijving, ':', statutaireNaam)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </roltoelichting>
         <betrokkeneIdentificatie>
             <xsl:if test="inn.nnpId != ''"><innNnpId><xsl:value-of select="inn.nnpId"/></innNnpId></xsl:if>
-            <xsl:if test="authentiek != ''"><authentiek><xsl:value-of select="authentiek"/></authentiek></xsl:if>
             <xsl:if test="ann.identificatie != ''"><annIdentificatie><xsl:value-of select="ann.identificatie"/></annIdentificatie></xsl:if>
             <xsl:if test="statutaireNaam != ''"><statutaireNaam><xsl:value-of select="statutaireNaam"/></statutaireNaam></xsl:if>
             <xsl:if test="inn.rechtsvorm != ''"><innRechtsvorm>
@@ -139,10 +156,18 @@
 
     <xsl:template match="*/*:gerelateerde/*:vestiging[@*:entiteittype='VES']">
         <betrokkeneType>vestiging</betrokkeneType>
-        <roltoelichting><xsl:value-of select="concat($ZgwRolTypeOmschrijving, ':', handelsnaam)"/></roltoelichting>
+        <roltoelichting>
+            <xsl:choose>
+                <xsl:when test="authentiek != ''">
+                    <xsl:value-of select="concat($ZgwRolTypeOmschrijving, ':', handelsnaam, ', {# authentiek:', authentiek, ' #}')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="concat($ZgwRolTypeOmschrijving, ':', handelsnaam)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </roltoelichting>
         <betrokkeneIdentificatie>
             <xsl:if test="vestigingsNummer != ''"><vestigingsNummer><xsl:value-of select="vestigingsNummer"/></vestigingsNummer></xsl:if>
-            <xsl:if test="authentiek != ''"><authentiek><xsl:value-of select="authentiek"/></authentiek></xsl:if>
             <xsl:if test="handelsnaam != ''"><handelsnaam><xsl:value-of select="handelsnaam"/></handelsnaam></xsl:if>
             <xsl:if test="verblijfsadres/aoa.identificatie != '' and verblijfsadres/wpl.woonplaatsNaam != '' and verblijfsadres/gor.openbareRuimteNaam != '' and verblijfsadres/aoa.huisnummer != ''">
                 <xsl:apply-templates select="verblijfsadres"/>

--- a/src/main/configurations/Translate/CreeerZaak_LK01/xsl/MapZdsRolFromZgwRol.xslt
+++ b/src/main/configurations/Translate/CreeerZaak_LK01/xsl/MapZdsRolFromZgwRol.xslt
@@ -23,7 +23,10 @@
                 <ZKN:natuurlijkPersoon StUF:entiteittype="NPS">
                     <xsl:if test="betrokkeneIdentificatie/inpBsn != ''">
                         <BG:inp.bsn><xsl:value-of select="betrokkeneIdentificatie/inpBsn"/></BG:inp.bsn>
-                        <BG:authentiek StUF:metagegeven="true">N</BG:authentiek> <!-- Required by ZDS schema, but no place to store in ZGW -->
+                        <xsl:apply-templates select="roltoelichting"/> <!-- To get authentiek value -->
+                    </xsl:if>
+                    <xsl:if test="betrokkeneIdentificatie/anpIdentificatie != ''">
+                        <BG:anp.identificatie><xsl:value-of select="betrokkeneIdentificatie/anpIdentificatie"/></BG:anp.identificatie>
                     </xsl:if>
                     <xsl:if test="betrokkeneIdentificatie/geslachtsnaam != ''">
                         <BG:geslachtsnaam><xsl:value-of select="betrokkeneIdentificatie/geslachtsnaam"/></BG:geslachtsnaam>
@@ -57,7 +60,7 @@
                 <ZKN:nietNatuurlijkPersoon StUF:entiteittype="NNP">
                     <xsl:if test="betrokkeneIdentificatie/innNnpId != ''">
                         <BG:inn.nnpId><xsl:value-of select="betrokkeneIdentificatie/innNnpId" /></BG:inn.nnpId>
-                        <BG:authentiek StUF:metagegeven="true">N</BG:authentiek> <!-- Required by ZDS schema, but no place to store in ZGW -->
+                        <xsl:apply-templates select="roltoelichting"/> <!-- To get authentiek value -->
                     </xsl:if>
                     <xsl:if test="betrokkeneIdentificatie/annIdentificatie != ''">
                         <BG:ann.identificatie><xsl:value-of select="betrokkeneIdentificatie/annIdentificatie"/></BG:ann.identificatie>
@@ -84,6 +87,7 @@
                     <xsl:if test="betrokkeneIdentificatie/vestigingsNummer != ''">
                         <BG:vestigingsNummer><xsl:value-of select="betrokkeneIdentificatie/vestigingsNummer"/></BG:vestigingsNummer>
                     </xsl:if>
+                    <xsl:apply-templates select="roltoelichting"/> <!-- To get authentiek value -->
                     <xsl:for-each select="betrokkeneIdentificatie/handelsnaam">
                         <BG:handelsnaam><xsl:value-of select="."/></BG:handelsnaam>
                     </xsl:for-each>
@@ -166,5 +170,22 @@
             </BG:verblijfsadres>
         </xsl:if>
     </xsl:template>
+
+    <xsl:template match="roltoelichting">
+        <xsl:variable name="authentiekValue">
+            <xsl:value-of select="substring-before(substring-after(., '{# authentiek:'), ' #}')"/>
+        </xsl:variable>
+        <BG:authentiek StUF:metagegeven="true">
+            <xsl:choose>
+                <xsl:when test="string-length($authentiekValue) gt 0">
+                    <xsl:value-of select="$authentiekValue"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>N</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </BG:authentiek>
+    </xsl:template>
+
 
 </xsl:stylesheet>

--- a/src/test/testtool/ZgwRol/ZgwRol/out.xml
+++ b/src/test/testtool/ZgwRol/ZgwRol/out.xml
@@ -3,7 +3,7 @@
     <omschrijving>Initiator</omschrijving>
     <omschrijvingGeneriek>initiator</omschrijvingGeneriek>
     <betrokkeneType>natuurlijk_persoon</betrokkeneType>
-    <roltoelichting>Initiator:Precies</roltoelichting>
+    <roltoelichting>Initiator:Precies, {# authentiek:J #}</roltoelichting>
     <betrokkeneIdentificatie>
         <inpBsn>111111110</inpBsn>
         <authentiek>J</authentiek>


### PR DESCRIPTION
There is no 'authentiek' field which is used in roles in Openzaak but we needed to save its value. We now save the authentiek value in the field of 'roltoelichting' of OpenZaak in the form of "{# authentiek:', _value_, ' #}" so that we could understand the structure and map it to zds form on the way back.