### PR TITLE
build: remove outdated custom JVM memory configuration so that a modern garbage collector is used instead

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# Kan verwijderd worden bij nieuwe change op docker image van het framework 
+# Temporary workaround until the framework Docker image provides the desired JVM defaults.
 export JAVA_OPTS="\
 	-XX:HeapDumpPath=/usr/local/tomcat/logs \
 	-XX:+HeapDumpOnOutOfMemoryError \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,12 +14,14 @@ export JAVA_OPTS="\
 	--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
 	$JAVA_OPTS"
 
-# By default, GC debugging is disabled. Enable it when dtap.stage is LOC.
-DTAP_STAGE="$(printenv 'dtap.stage' 2>/dev/null || true)"
-if [ "$DTAP_STAGE" = "LOC" ]; then
-	export JAVA_OPTS="-Xlog:gc*,gc+age=trace:file=/usr/local/tomcat/logs/gc-log.log:time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"
+# By default, GC debugging is disabled. Enable it when GC_LOGGING_ENABLED is LOC.
+if [ ${GC_LOGGING_ENABLED:-false} == true ]
+	then
+		export JAVA_OPTS="-Xlog:gc*,gc+age=trace:file=/usr/local/tomcat/logs/gc-log.log:time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"
 else
 	export JAVA_OPTS="-XX:+PerfDisableSharedMem $JAVA_OPTS"
 fi
+
+
 
 exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,7 +14,7 @@ export JAVA_OPTS="\
 	--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
 	$JAVA_OPTS"
 
-# By default, GC debugging is disabled. Enable it when GC_LOGGING_ENABLED is LOC.
+# By default, GC debugging is disabled. Enable it when GC_LOGGING_ENABLED is true.
 if [ ${GC_LOGGING_ENABLED:-false} == true ]
 	then
 		export JAVA_OPTS="-Xlog:gc*,gc+age=trace:file=/usr/local/tomcat/logs/gc-log.log:time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,30 +1,25 @@
 #!/usr/bin/env bash
 set -e
 
-# Append HeapDump and GC properties to existing JAVA_OPTS
+# Kan verwijderd worden bij nieuwe change op docker image van het framework 
 export JAVA_OPTS="\
 	-XX:HeapDumpPath=/usr/local/tomcat/logs \
 	-XX:+HeapDumpOnOutOfMemoryError \
-	-XX:+UseG1GC \
-	-XX:-ShrinkHeapInSteps \
-	-XX:+UnlockExperimentalVMOptions \
-	-XX:G1ReservePercent=20 \
-	-XX:InitiatingHeapOccupancyPercent=25 \
-	-XX:SurvivorRatio=32 \
-	-XX:+PerfDisableSharedMem \
-	-XX:+ParallelRefProcEnabled \
-	-XX:MaxTenuringThreshold=3 \
-	-XX:MaxGCPauseMillis=200 \
-	-XX:+UseStringDeduplication \
-	-XX:MaxMetaspaceSize=256m \
-	-XX:G1HeapRegionSize=16m \
-	-XX:G1NewSizePercent=30 \
+	-XX:+UseCompactObjectHeaders \
+	--add-modules java.se \
+	--add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
+	--add-opens java.base/java.lang=ALL-UNNAMED \
+	--add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+	--add-opens java.management/sun.management=ALL-UNNAMED \
+	--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
 	$JAVA_OPTS"
 
-# Enables writing of GC logs to /usr/local/tomcat/logs. Impacts performance!
-if [ ${GC_LOGGING_ENABLED:-false} == true ]
-	then
-		export JAVA_OPTS="-Xlog:codecache+sweep*=trace,class+unload,class+load,os+thread,safepoint,gc*,gc+stringdedup=debug,gc+ergo=trace,gc+age=trace,gc+phases=trace,gc+humongous=trace,jit+compilation=debug:file=/usr/local/tomcat/logs/zaakbrug-gc-log.log:level,tags,time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"
+# By default, GC debugging is disabled. Enable it when dtap.stage is LOC.
+DTAP_STAGE="$(printenv 'dtap.stage' 2>/dev/null || true)"
+if [ "$DTAP_STAGE" = "LOC" ]; then
+	export JAVA_OPTS="-Xlog:gc*,gc+age=trace:file=/usr/local/tomcat/logs/gc-log.log:time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"
+else
+	export JAVA_OPTS="-XX:+PerfDisableSharedMem $JAVA_OPTS"
 fi
 
 exec "$@"


### PR DESCRIPTION
vooruitlopend op de change in het framework docker image GC instellingen