### PR TITLE
Error handling

### DIFF
--- a/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
@@ -20,18 +20,21 @@ local requestUrl = if std.type(url) == "string" then url else "";
     else "TechnicalError",
 
   reason:
-    if status == 400 then
-      "400 Bad Request from ZGW API received by " + sender
-    else if status == 401 then
-      "401 Unauthorized from ZGW API received by " + sender
-    else if status == 403 then
-      "403 Forbidden from ZGW API received by " + sender
-    else if status == 404 then
-      "404 Not Found from ZGW API received by " + sender
-    else if status == 500 then
-      "500 Internal Server Error from ZGW API received by " + sender
+    if std.length(statusMatch) > 0 then
+      if status == 400 then
+        "400 Bad Request from ZGW API received by " + sender
+      else if status == 401 then
+        "401 Unauthorized from ZGW API received by " + sender
+      else if status == 403 then
+        "403 Forbidden from ZGW API received by " + sender
+      else if status == 404 then
+        "404 Not Found from ZGW API received by " + sender
+      else if status == 500 then
+        "500 Internal Server Error from ZGW API received by " + sender
+      else
+        "some negative response from ZGW API received by " + sender
     else
-      "some negative response from ZGW API received by " + sender,
+      "some negative NON ZGW API response received by " + sender,
 
   request: requestUrl,
 

--- a/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
@@ -1,42 +1,19 @@
-local get(obj, field) =
-  if std.type(obj) == "object" && std.objectHas(obj, field) then obj[field] else "";
-
-local statusMatch = std.findSubstr("\"status\"", CDATA);
-
-local statusIndex =
-  if std.length(statusMatch) > 0 then statusMatch[0] else -1;
-
-local status =
-  if statusIndex >= 0 then
-    std.parseInt(std.substr(CDATA, statusIndex + 9, 3))
-  else
-    0;
-local sender = if std.type(senderPipeName) == "string" then senderPipeName else "";
-local requestUrl = if std.type(url) == "string" then url else "";
-
+local statusCode = std.parseInt(httpStatus) default null;
+local jsonResponse = std.parseJson(responsePlainText) default null;
 {
-  code:
-    if status == 400 then "TranslationError"
-    else "TechnicalError",
-
+  code: if(statusCode != null && statusCode == 400) then "TranslationError" else "TechnicalError",
   reason:
-    if std.length(statusMatch) > 0 then
-      if status == 400 then
-        "400 Bad Request from ZGW API received by " + sender
-      else if status == 401 then
-        "401 Unauthorized from ZGW API received by " + sender
-      else if status == 403 then
-        "403 Forbidden from ZGW API received by " + sender
-      else if status == 404 then
-        "404 Not Found from ZGW API received by " + sender
-      else if status == 500 then
-        "500 Internal Server Error from ZGW API received by " + sender
-      else
-        "some negative response from ZGW API received by " + sender
+    if (statusCode != null && jsonResponse != null) then
+        "[" + statusCode + " " + httpReasonPhrase + " '" + (jsonResponse.code default "") + "'] error response from ZGW API received by " + senderPipeName
     else
-      "some negative NON ZGW API response received by " + sender,
+      "[" + statusCode + " " + httpReasonPhrase + "] error response received by " + senderPipeName,
 
-  request: requestUrl,
+  details: "url: [" + (url default "") + "]"
+    + ", description: [" + (jsonResponse.detail default "") + "]",
 
-  detailsXml: CDATA
+  detailsXml: {
+    url: url default null,
+    description: jsonResponse.detail default null,
+    response: if(jsonResponse != null) then jsonResponse else ds.regex.regexReplace(ds.trim(responsePlainText), "\\s+", " ")
+  }
 }

--- a/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
@@ -1,29 +1,39 @@
+local get(obj, field) =
+  if std.type(obj) == "object" && std.objectHas(obj, field) then obj[field] else "";
+
+local status = get(payload, "status");
+local sender = if std.type(senderPipeName) == "string" then senderPipeName else "";
+local requestUrl = if std.type(url) == "string" then url else "";
+
 {
   code:
-    if payload.status == 400 then "TranslationError"
+    if status == 400 then "TranslationError"
     else "TechnicalError",
 
   reason:
-    if payload.status == 400 then
-      "400 Bad Request from ZGW API received by " + senderPipeName
-    else if payload.status == 401 then
-      "401 Unauthorized from ZGW API received by " + senderPipeName
-    else if payload.status == 403 then
-      "403 Forbidden from ZGW API received by " + senderPipeName
-    else if payload.status == 404 then
-      "404 Not Found from ZGW API received by " + senderPipeName
-    else if payload.status == 500 then
-      "500 Internal Server Error from ZGW API received by " + senderPipeName
+    if status == 400 then
+      "400 Bad Request from ZGW API received by " + sender
+    else if status == 401 then
+      "401 Unauthorized from ZGW API received by " + sender
+    else if status == 403 then
+      "403 Forbidden from ZGW API received by " + sender
+    else if status == 404 then
+      "404 Not Found from ZGW API received by " + sender
+    else if status == 500 then
+      "500 Internal Server Error from ZGW API received by " + sender
     else
-      "some negative response from ZGW API received by " + senderPipeName,
+      "some negative response from ZGW API received by " + sender,
+
+  request: requestUrl,
 
   details:
     std.join(" ", [
-      payload.code,
-      payload.title,
-      std.toString(payload.status),
-      payload.detail,
+      get(payload, "code"),
+      get(payload, "title"),
+      if status == "" then "" else std.toString(status),
+      get(payload, "detail"),
     ]),
 
-  detailsXml: payload,
+  detailsXml:
+    if std.type(payload) == "object" then payload else {},
 }

--- a/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
@@ -34,6 +34,6 @@ local requestUrl = if std.type(url) == "string" then url else "";
       get(payload, "detail"),
     ]),
 
-  detailsXml:
-    if std.type(payload) == "object" then payload else {},
+
+  detailsXml: [CDATA]
 }

--- a/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
@@ -1,7 +1,16 @@
 local get(obj, field) =
   if std.type(obj) == "object" && std.objectHas(obj, field) then obj[field] else "";
 
-local status = get(payload, "status");
+local statusMatch = std.findSubstr("\"status\"", CDATA);
+
+local statusIndex =
+  if std.length(statusMatch) > 0 then statusMatch[0] else -1;
+
+local status =
+  if statusIndex >= 0 then
+    std.parseInt(std.substr(CDATA, statusIndex + 9, 3))
+  else
+    0;
 local sender = if std.type(senderPipeName) == "string" then senderPipeName else "";
 local requestUrl = if std.type(url) == "string" then url else "";
 
@@ -26,14 +35,5 @@ local requestUrl = if std.type(url) == "string" then url else "";
 
   request: requestUrl,
 
-  details:
-    std.join(" ", [
-      get(payload, "code"),
-      get(payload, "title"),
-      if status == "" then "" else std.toString(status),
-      get(payload, "detail"),
-    ]),
-
-
-  detailsXml: [CDATA]
+  detailsXml: CDATA
 }

--- a/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/ParseNegativeHttpResult.jsonnet
@@ -1,0 +1,29 @@
+{
+  code:
+    if payload.status == 400 then "TranslationError"
+    else "TechnicalError",
+
+  reason:
+    if payload.status == 400 then
+      "400 Bad Request from ZGW API received by " + senderPipeName
+    else if payload.status == 401 then
+      "401 Unauthorized from ZGW API received by " + senderPipeName
+    else if payload.status == 403 then
+      "403 Forbidden from ZGW API received by " + senderPipeName
+    else if payload.status == 404 then
+      "404 Not Found from ZGW API received by " + senderPipeName
+    else if payload.status == 500 then
+      "500 Internal Server Error from ZGW API received by " + senderPipeName
+    else
+      "some negative response from ZGW API received by " + senderPipeName,
+
+  details:
+    std.join(" ", [
+      payload.code,
+      payload.title,
+      std.toString(payload.status),
+      payload.detail,
+    ]),
+
+  detailsXml: payload,
+}

--- a/src/main/configurations/Translate/Common/jsonnet/transformErrorMessage.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/transformErrorMessage.jsonnet
@@ -1,6 +1,0 @@
-{
-  code: payload.status,
-  reason: payload.title,
-  details: payload.detail,
-  detailsXML: payload
-}+

--- a/src/main/configurations/Translate/Common/jsonnet/transformErrorMessage.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/transformErrorMessage.jsonnet
@@ -1,0 +1,6 @@
+{
+  code: payload.status,
+  reason: payload.title,
+  details: payload.detail,
+  detailsXML: payload
+}+

--- a/src/main/configurations/Translate/Common/jsonnet/unwrapJsonEnvelope.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/unwrapJsonEnvelope.jsonnet
@@ -2,7 +2,5 @@ if std.type(payload) != "object" then
   error "Expected 'payload' to be a JSON object."
 else if !std.objectHas(payload, "results") then
   error "Expected property 'payload.results' to exist."
-else if std.type(payload.results) != "array" then
-  error "Expected 'payload.results' to be an array."
 else
   payload.results

--- a/src/main/configurations/Translate/Common/jsonnet/unwrapJsonEnvelope.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/unwrapJsonEnvelope.jsonnet
@@ -1,6 +1,8 @@
-{
-  [Type]: [
-    item
-    for item in payload.results
-  ]
-}
+if std.type(payload) != "object" then
+  error "Expected 'payload' to be a JSON object."
+else if !std.objectHas(payload, "results") then
+  error "Expected property 'payload.results' to exist."
+else if std.type(payload.results) != "array" then
+  error "Expected 'payload.results' to be an array."
+else
+  payload.results

--- a/src/main/configurations/Translate/Common/jsonnet/unwrapJsonEnvelope.jsonnet
+++ b/src/main/configurations/Translate/Common/jsonnet/unwrapJsonEnvelope.jsonnet
@@ -1,0 +1,6 @@
+{
+  [Type]: [
+    item
+    for item in payload.results
+  ]
+}

--- a/src/main/configurations/Translate/Common/xsl/BackEndError.xsl
+++ b/src/main/configurations/Translate/Common/xsl/BackEndError.xsl
@@ -6,9 +6,6 @@
     </xsl:template>
     <xsl:template match="error">
         <xsl:choose>
-            <xsl:when test="normalize-space(code)">
-                <xsl:value-of select="code"/>
-            </xsl:when>
             <xsl:when test="code='TechnicalError'">500</xsl:when>
             <xsl:when test="code='TranslationError'">400</xsl:when>
             <xsl:when test="code='ConfigurationError'">500</xsl:when>

--- a/src/main/configurations/Translate/Common/xsl/BackEndError.xsl
+++ b/src/main/configurations/Translate/Common/xsl/BackEndError.xsl
@@ -6,6 +6,9 @@
     </xsl:template>
     <xsl:template match="error">
         <xsl:choose>
+            <xsl:when test="normalize-space(code)">
+                <xsl:value-of select="code"/>
+            </xsl:when>
             <xsl:when test="code='TechnicalError'">500</xsl:when>
             <xsl:when test="code='TranslationError'">400</xsl:when>
             <xsl:when test="code='ConfigurationError'">500</xsl:when>

--- a/src/main/configurations/Translate/Configuration_CreeerZaak_LK01.xml
+++ b/src/main/configurations/Translate/Configuration_CreeerZaak_LK01.xml
@@ -118,6 +118,8 @@
                     returnedSessionKeys="Error">
                     <Param name="Url" xpathExpression="/roltypen" />
                 </IbisLocalSender>
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe
@@ -295,8 +297,8 @@
                     javaListener="Zaken_DeleteZgwZaak">
                     <Param name="url" sessionKey="PostZgwZaakResult" xpathExpression="ZgwZaak/url" />
                 </IbisLocalSender>
-                <Forward name="success" path="EXCEPTION" />
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="success" path="UncaughtException" />
+                <Forward name="exception" path="UncaughtException" />
             </SenderPipe>
 
             <IfPipe name="CheckForHeeftBetrekkingOpAndere"
@@ -340,7 +342,7 @@
                     <Param name="DeelzaakIdentificatie" xpathExpression="heeftAlsDeelzaak/gerelateerde/identificatie" />
                 </IbisLocalSender>
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
             
             <XsltPipe 

--- a/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
@@ -107,7 +107,8 @@
             </IfPipe>
 
             <SenderPipe
-                name="DeleteRol">
+                name="DeleteRol"
+                storeResultInSessionKey="response">
                 <HttpSender
                     name="DeleteRolSender" 
                     methodType="DELETE"
@@ -131,6 +132,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" xpathExpression="Rollen/Rol/url"/>
                 <Param name="senderPipeName" value="DeleteRol" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
@@ -129,6 +129,7 @@
             </SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="Rollen/Rol/url"/>
                 <Param name="senderPipeName" value="DeleteRol" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
@@ -125,17 +125,18 @@
                     <Param name="Authorization"  sessionKey="Authorization" />
                 </HttpSender>
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="DeleteRol" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
+            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
@@ -129,7 +129,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" xpathExpression="Rollen/Rol/url"/>
                 <Param name="senderPipeName" value="DeleteRol" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
@@ -125,9 +125,26 @@
                     <Param name="Accept-Crs" value="EPSG:4326"/>
                     <Param name="Authorization"  sessionKey="Authorization" />
                 </HttpSender>
-                <Forward name="success" path="EXIT"/>
+                <Forward name="success" path="ResponseTypeSwitch"/>
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteRolFromZgw.xml
@@ -129,12 +129,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" xpathExpression="Rollen/Rol/url"/>
-                <Param name="senderPipeName" value="DeleteRol" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
@@ -69,6 +69,7 @@
             </SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="ZgwZaakobjectUrlForDeletion"/>
                 <Param name="senderPipeName" value="DeleteZaakobject" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
@@ -65,17 +65,18 @@
                     <Param name="Authorization"  sessionKey="Authorization" />
                 </HttpSender>
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="DeleteZaakobject" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
+            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
@@ -69,7 +69,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwZaakobjectUrlForDeletion"/>
                 <Param name="senderPipeName" value="DeleteZaakobject" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
@@ -47,7 +47,8 @@
             </PutInSessionPipe>
 
             <SenderPipe
-                name="DeleteZgwZaakobject">
+                name="DeleteZgwZaakobject"
+                storeResultInSessionKey="response">
                 <HttpSender
                     name="DeleteZgwZaakobjectSender"
                     methodType="DELETE"
@@ -71,6 +72,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwZaakobjectUrlForDeletion"/>
                 <Param name="senderPipeName" value="DeleteZaakobject" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
@@ -65,9 +65,26 @@
                     <Param name="Accept-Crs" value="EPSG:4326"/>
                     <Param name="Authorization"  sessionKey="Authorization" />
                 </HttpSender>
-                <Forward name="success" path="EXIT"/>
+                <Forward name="success" path="ResponseTypeSwitch"/>
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_DeleteZaakobjectFromZgw.xml
@@ -69,12 +69,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwZaakobjectUrlForDeletion"/>
-                <Param name="senderPipeName" value="DeleteZaakobject" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
@@ -25,7 +25,8 @@
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
 
-            <SenderPipe name="PostZgwZaakInformatieObjectSender" getInputFromSessionKey="originalMessage">
+            <SenderPipe name="PostZgwZaakInformatieObjectSender" getInputFromSessionKey="originalMessage"
+                storeResultInSessionKey="response">
                 <Json2XmlInputValidator name="ValidatePost"
                     schema="Zgw/Zaken/Model/PostZgwZaakInformatieObject.xsd"
                     root="ZgwZaakInformatieObject"
@@ -61,6 +62,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaakinformatieobjecten"/>
                 <Param name="senderPipeName" value="PostZgwZaakInformatieObjectSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
@@ -59,7 +59,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaakinformatieobjecten"/>
                 <Param name="senderPipeName" value="PostZgwZaakInformatieObjectSender" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
@@ -69,18 +69,14 @@
 
             <JsonPipe
                 name="JsonToXml"
+                rootElementName="ZgwZaakInformatieObject"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
             >
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-            >
-                <Param name="Type" value="ZgwZaakInformatieObject" />
                 <Forward name="success" path="EXIT" />
                 <Forward name="exception" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
+
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
@@ -59,6 +59,7 @@
             </SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaakinformatieobjecten"/>
                 <Param name="senderPipeName" value="PostZgwZaakInformatieObjectSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
@@ -55,16 +55,17 @@
                 </HttpSender>
 
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostZgwZaakInformatieObjectSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe
                 name="JsonToXml"

--- a/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
@@ -59,12 +59,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaakinformatieobjecten"/>
-                <Param name="senderPipeName" value="PostZgwZaakInformatieObjectSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Documenten_PostZgwEnkelvoudigInformatieObject.xml
@@ -55,9 +55,41 @@
                     <Param name="Authorization" sessionKey="Authorization" />
                 </HttpSender>
 
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
+                >
+                <Param name="Type" value="ZgwEnkelvoudigInformatieObject" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -74,17 +106,6 @@
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
-
-            <JsonPipe
-                name="JsonToXml"
-                rootElementName="ZgwZaakInformatieObject"
-                unlessSessionKey="responseType"
-                unlessValue="application/json"
-            >
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
-            </JsonPipe>
-
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
@@ -49,6 +49,7 @@
 
             <ForEachChildElementPipe name="ZgwZaakInformatieObjectenIterator"
                 elementXPathExpression="/ZgwZaakInformatieObjecten/ZgwZaakInformatieObject"
+                ignoreExceptions="true"
                 parallel="true"
                 maxChildThreads="20">
                 <IbisLocalSender
@@ -56,9 +57,37 @@
                     javaListener="HandleZgwZaakInformatieObjecten"
                     returnedSessionKeys="Error">
                 </IbisLocalSender>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="success" path="CheckForExceptions"/>
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
+
+            <!-- only needed when parallel is set to true -->
+            <IfPipe name="CheckForExceptions"
+                xpathExpression="exists(*/result/exception)"
+                >
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Forward name="then" path="getError"/>
+                <Forward name="else" path="EXIT"/>
+            </IfPipe>
+            
+            <PutInSessionPipe name="getError">
+                <Param name="Error" xpathExpression="string((//exception)[1])"/>
+                <Forward name="success" path="UncaughtException" />
+            </PutInSessionPipe>
+            
+            <XsltPipe 
+                name="UncaughtException"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> <!-- codes: TechnicalError, TranslationError, ConfigurationError-->
+                <Param name="reason" pattern="Uncaught exception" /> 
+                <!-- <Param name="details" sessionKey="" /> -->
+                <Param name="detailsXml" type="DOMDOC" />
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GeefZaakdetails_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_GeefZaakdetails_Lv01.xml
@@ -113,8 +113,22 @@
                     returnedSessionKeys="Error">
                 </IbisLocalSender>
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
+            
+            <XsltPipe 
+                name="UncaughtException"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> <!-- codes: TechnicalError, TranslationError, ConfigurationError-->
+                <Param name="reason" pattern="Uncaught exception" /> 
+                <!-- <Param name="details" sessionKey="" /> -->
+                <Param name="detailsXml" type="DOMDOC" />
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
+++ b/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
@@ -55,7 +55,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="CallGetBas64Inhoud" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$ref_inhoud" >

--- a/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
+++ b/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
@@ -56,6 +56,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="CallGetBas64Inhoud" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
+++ b/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
@@ -58,8 +58,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="CallGetBas64Inhoud" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$ref_inhoud" >
-                    <Param name="ref_inhoud" sessionKey="ref_inhoud" />
+                <!-- We dont want big document base64 to end up in logging -->
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" value="" />
                 </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
+++ b/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
@@ -52,22 +52,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EncodeInhoud" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <JsonPipe
-                name="ErrorJsonToXml"
-                >
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl"
-                >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="CallGetBas64Inhoud" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <Base64Pipe 
                 name="EncodeInhoud"

--- a/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
+++ b/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
@@ -58,6 +58,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="CallGetBas64Inhoud" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$ref_inhoud" >
+                    <Param name="ref_inhoud" sessionKey="ref_inhoud" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
+++ b/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
@@ -57,11 +57,13 @@
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
-                <Param name="senderPipeName" value="CallGetBas64Inhoud" />
                 <!-- We dont want big document base64 to end up in logging -->
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" value="" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
+++ b/src/main/configurations/Translate/Configuration_GetBas64Inhoud.xml
@@ -61,9 +61,9 @@
                 <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" value="" />
                 </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Param name="senderPipeName" sessionKey="ref_inhoud" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="ref_inhoud" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="ref_inhoud" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
@@ -48,8 +48,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
                             'resultaattypen?zaaktype=',
                             $zaaktype)" >
                     <Param name="zaaktype" sessionKey="ZaakTypeUrl" />

--- a/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetResultaatTypesByZaakType" 
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetResultaatTypesByZaakTypeSender" 
 					methodType="GET"
@@ -54,6 +55,9 @@
                     <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 </Param>
                 <Param name="senderPipeName" value="GetResultaatTypesByZaakType" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
@@ -44,16 +44,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetResultaatTypesByZaakType" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="GetZgwResultaatTypeByOmschrijving"/>

--- a/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
@@ -48,6 +48,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
+                            'resultaattypen?zaaktype=',
+                            $zaaktype)" >
+                    <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
+                </Param>
                 <Param name="senderPipeName" value="GetResultaatTypesByZaakType" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
@@ -44,9 +44,47 @@
                 <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXCEPTION" />  <!-- to be implemented -->
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <!-- <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe> -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="GetZgwResultaatTypeByOmschrijving" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="GetZgwResultaatTypeByOmschrijving"
+                styleSheetName="CreeerZaak_LK01/xsl/GetZgwResultaatTypeByOmschrijving.xsl"
+                >
+                <Param name="Omschrijving" sessionKey="Omschrijving"/>
+                <Forward name="success" path="CheckForGetResultaatTypeResult"/>
+            </XsltPipe>
+
+            <IfPipe name="CheckForGetResultaatTypeResult"
+                xpathExpression="string-length(resultaatType) > 0"
+                >
+                <Forward name="then" path="EXIT"/>
+                <Forward name="else" path="EXCEPTION"/>
+            </IfPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -67,25 +105,6 @@
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
-
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="GetZgwResultaatTypeByOmschrijving"/>
-            </JsonPipe>
-
-            <XsltPipe
-                name="GetZgwResultaatTypeByOmschrijving"
-                styleSheetName="CreeerZaak_LK01/xsl/GetZgwResultaatTypeByOmschrijving.xsl"
-                >
-                <Param name="Omschrijving" sessionKey="Omschrijving"/>
-                <Forward name="success" path="CheckForGetResultaatTypeResult"/>
-            </XsltPipe>
-
-            <IfPipe name="CheckForGetResultaatTypeResult"
-                xpathExpression="string-length(resultaatType) > 0"
-                >
-                <Forward name="then" path="EXIT"/>
-                <Forward name="else" path="EXCEPTION"/>
-            </IfPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultaatTypeByZaakTypeAndOmschrijving.xml
@@ -48,16 +48,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
                             'resultaattypen?zaaktype=',
                             $zaaktype)" >
                     <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 </Param>
-                <Param name="senderPipeName" value="GetResultaatTypesByZaakType" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZgwResultatenByZaakUrl" 
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwResultatenByZaakUrlSender" 
 					methodType="GET"
@@ -54,6 +55,9 @@
                     <Param name="zaak" sessionKey="ZaakUrl" />
                 </Param>
                 <Param name="senderPipeName" value="GetZgwResultatenByZaakUrl" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
@@ -48,8 +48,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'resultaten?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZaakUrl" />

--- a/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
@@ -48,6 +48,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'resultaten?zaak=',
+                            $zaak)">
+                    <Param name="zaak" sessionKey="ZaakUrl" />
+                </Param>
                 <Param name="senderPipeName" value="GetZgwResultatenByZaakUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
@@ -44,16 +44,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwResultatenByZaakUrl" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="EXIT"/>

--- a/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetResultatenByZaakUrl.xml
@@ -44,9 +44,26 @@
                 <Param name="zaak" sessionKey="ZaakUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
@@ -65,9 +82,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="EXIT"/>
-            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
@@ -57,6 +57,30 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="
+                            concat(
+                                '${zaakbrug.zgw.zaken-api.root-url}',
+                                'rollen?',
+                                'zaak=', $zaak,
+                                '&amp;roltype=', $roltype,
+                                '&amp;betrokkeneIdentificatie__natuurlijkPersoon__inpBsn=', $betrokkeneIdentificatie__natuurlijkPersoon__inpBsn,
+                                '&amp;betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie=', $betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie,
+                                '&amp;betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId=', $betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId,
+                                '&amp;betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie=', $betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie,
+                                '&amp;betrokkeneIdentificatie__vestiging__vestigingsNummer=', $betrokkeneIdentificatie__vestiging__vestigingsNummer,
+                                '&amp;betrokkeneIdentificatie__organisatorischeEenheid__identificatie=', $betrokkeneIdentificatie__organisatorischeEenheid__identificatie,
+                                '&amp;betrokkeneIdentificatie__medewerker__identificatie=', $betrokkeneIdentificatie__medewerker__identificatie
+                            )">
+                    <Param name="zaak" sessionKey="ZaakUrl"/>
+                    <Param name="roltype" sessionKey="RolTypeUrl"/>
+                    <Param name="betrokkeneIdentificatie__natuurlijkPersoon__inpBsn" sessionKey="inpBsn"/>
+                    <Param name="betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie" sessionKey="anpIdentificatie"/>
+                    <Param name="betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId" sessionKey="innNnpId"/>
+                    <Param name="betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie" sessionKey="annIdentificatie"/>
+                    <Param name="betrokkeneIdentificatie__vestiging__vestigingsNummer" sessionKey="vestigingsNummer"/>
+                    <Param name="betrokkeneIdentificatie__organisatorischeEenheid__identificatie" sessionKey="OEHidentificatie"/>
+                    <Param name="betrokkeneIdentificatie__medewerker__identificatie" sessionKey="MDWidentificatie"/>
+                </Param>
                 <Param name="senderPipeName" value="GetRolByZaakUrlAndRolTypeUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
@@ -52,7 +52,7 @@
                 <Param name="betrokkeneIdentificatie__medewerker__identificatie" sessionKey="MDWidentificatie"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
@@ -65,20 +65,15 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapZgwRolToList"/>
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapZgwRolToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-                >
-                <Param name="List" value="Rollen"/>
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
                 <Param name="Type" value="Rol"/>
+                <Forward name="success" path="JsonToXml" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="Rollen">
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
+            </JsonPipe>
 
         </Pipeline>
     </Adapter>

--- a/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
@@ -57,7 +57,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" xpathExpression="
                             concat(
                                 '${zaakbrug.zgw.zaken-api.root-url}',

--- a/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
@@ -53,16 +53,18 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetRolByZaakUrlAndRolTypeUrl" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
+
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapZgwRolToList"/>

--- a/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetRolByZaakUrlAndRolTypeUrl" 
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetRolByZaakUrlAndRolTypeUrlSender" 
 					methodType="GET"
@@ -82,6 +83,9 @@
                     <Param name="betrokkeneIdentificatie__medewerker__identificatie" sessionKey="MDWidentificatie"/>
                 </Param>
                 <Param name="senderPipeName" value="GetRolByZaakUrlAndRolTypeUrl" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
@@ -57,6 +57,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" xpathExpression="
                             concat(
@@ -82,10 +83,12 @@
                     <Param name="betrokkeneIdentificatie__organisatorischeEenheid__identificatie" sessionKey="OEHidentificatie"/>
                     <Param name="betrokkeneIdentificatie__medewerker__identificatie" sessionKey="MDWidentificatie"/>
                 </Param>
-                <Param name="senderPipeName" value="GetRolByZaakUrlAndRolTypeUrl" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolByZaakUrlAndRolTypeUrl.xml
@@ -53,9 +53,42 @@
                 <Param name="betrokkeneIdentificatie__medewerker__identificatie" sessionKey="MDWidentificatie"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
+                >
+                <Param name="List" value="Rollen"/>
+                <Param name="Type" value="Rol"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -94,16 +127,6 @@
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="Rol"/>
-                <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="Rollen">
-                <Forward name="success" path="EXIT"/>
             </JsonPipe>
 
         </Pipeline>

--- a/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
@@ -43,17 +43,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe
                 name="JsonToXml">

--- a/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
@@ -47,6 +47,7 @@
             </SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="Url" />
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
@@ -24,7 +24,7 @@
             <SenderPipe
                 name="GetRolTypenByUrlSender"
                 getInputFromSessionKey="originalMessage"
-            >
+                storeResultInSessionKey="response">
                 <HttpSender
                     name="GetRolTypenByUrlHttpSender"
                     methodType="GET"
@@ -49,6 +49,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url" />
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
@@ -56,17 +56,15 @@
             </JsonPipe>
 
             <JsonPipe
-                name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt" >
-                <Param name="Type" value="ZgwRolType" />
+                name="JsonToXml"
+                rootElementName="ZgwRolType"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
+            >
                 <Forward name="success" path="EXIT" />
                 <Forward name="exception" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
+
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
@@ -46,7 +46,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url" />
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
@@ -42,9 +42,41 @@
                 <Param name="url" sessionKey="Url" />
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
+                >
+                <Param name="Type" value="ZgwRolType" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -60,16 +92,6 @@
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <JsonPipe
-                name="JsonToXml"
-                rootElementName="ZgwRolType"
-                unlessSessionKey="responseType"
-                unlessValue="application/json"
-            >
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
             </JsonPipe>
 
         </Pipeline>

--- a/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetRolTypenByUrl.xml
@@ -46,12 +46,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
             </SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url" />
-                <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
+++ b/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
@@ -48,8 +48,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'rollen?betrokkeneIdentificatie__natuurlijkPersoon__inpBsn=',
                             $betrokkeneIdentificatie__natuurlijkPersoon__inpBsn)">
                     <Param name="betrokkeneIdentificatie__natuurlijkPersoon__inpBsn" sessionKey="Bsn" />

--- a/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
+++ b/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
@@ -43,7 +43,7 @@
                 <Param name="betrokkeneIdentificatie__natuurlijkPersoon__inpBsn" sessionKey="Bsn" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
@@ -56,19 +56,16 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
+                <Param name="Type" value="ZgwRollen"/>
+                <Forward name="success" path="JsonToXml" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList"/>
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwRol">
+                <Forward name="success" path="EXIT"/>
             </JsonPipe>
 
-            <XsltPipe name="UnwrapOpenZaakApiEnvelopeToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-                >
-                <Param name="Type" value="ZgwRollen"/>
-                <Param name="List" value="ZgwRol"/>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
+++ b/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetRollenByBsn"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetRollenByBsnSender" 
 					methodType="GET"
@@ -54,6 +55,9 @@
                     <Param name="betrokkeneIdentificatie__natuurlijkPersoon__inpBsn" sessionKey="Bsn" />
                 </Param>
                 <Param name="senderPipeName" value="GetRollenByBsn" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
+++ b/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
@@ -44,16 +44,18 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetRollenByBsn" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
+
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList"/>

--- a/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
+++ b/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
@@ -48,6 +48,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'rollen?betrokkeneIdentificatie__natuurlijkPersoon__inpBsn=',
+                            $betrokkeneIdentificatie__natuurlijkPersoon__inpBsn)">
+                    <Param name="betrokkeneIdentificatie__natuurlijkPersoon__inpBsn" sessionKey="Bsn" />
+                </Param>
                 <Param name="senderPipeName" value="GetRollenByBsn" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
+++ b/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
@@ -44,9 +44,42 @@
                 <Param name="betrokkeneIdentificatie__natuurlijkPersoon__inpBsn" sessionKey="Bsn" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
+                >
+                <Param name="List" value="Rollen"/>
+                <Param name="Type" value="Rol"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -66,16 +99,6 @@
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="ZgwRollen"/>
-                <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwRol">
-                <Forward name="success" path="EXIT"/>
             </JsonPipe>
 
         </Pipeline>

--- a/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
+++ b/src/main/configurations/Translate/Configuration_GetRollenByBsn.xml
@@ -48,16 +48,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'rollen?betrokkeneIdentificatie__natuurlijkPersoon__inpBsn=',
                             $betrokkeneIdentificatie__natuurlijkPersoon__inpBsn)">
                     <Param name="betrokkeneIdentificatie__natuurlijkPersoon__inpBsn" sessionKey="Bsn" />
                 </Param>
-                <Param name="senderPipeName" value="GetRollenByBsn" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
+++ b/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
@@ -43,7 +43,7 @@
                 <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
@@ -56,18 +56,16 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList"/>
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
+                <Param name="Type" value="ZgwStatusType"/>
+                <Forward name="success" path="JsonToXml" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwStatusTypes">
+                <Forward name="success" path="EXIT"/>
             </JsonPipe>
 
-            <XsltPipe name="UnwrapOpenZaakApiEnvelopeToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-                >
-                <Param name="Type" value="ZgwStatusType"/>
-                <Param name="List" value="ZgwStatusTypes"/>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
+++ b/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetStatusTypesByZaakType"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetStatusTypesByZaakTypeSender" 
 					methodType="GET"
@@ -54,6 +55,9 @@
                     <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 </Param>
                 <Param name="senderPipeName" value="GetStatusTypesByZaakType" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
+++ b/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
@@ -44,16 +44,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetStatusTypesByZaakType" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList"/>

--- a/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
+++ b/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
@@ -48,6 +48,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
+                            'statustypen?zaaktype=',
+                            $zaaktype)">
+                    <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
+                </Param>
                 <Param name="senderPipeName" value="GetStatusTypesByZaakType" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
+++ b/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
@@ -48,8 +48,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
                             'statustypen?zaaktype=',
                             $zaaktype)">
                     <Param name="zaaktype" sessionKey="ZaakTypeUrl" />

--- a/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
+++ b/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
@@ -48,16 +48,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
                             'statustypen?zaaktype=',
                             $zaaktype)">
                     <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 </Param>
-                <Param name="senderPipeName" value="GetStatusTypesByZaakType" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
+++ b/src/main/configurations/Translate/Configuration_GetStatusTypes.xml
@@ -44,9 +44,42 @@
                 <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
+                >
+                <Param name="List" value="ZgwStatusTypes"/>
+                <Param name="Type" value="ZgwStatusType"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -66,16 +99,6 @@
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="ZgwStatusType"/>
-                <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwStatusTypes">
-                <Forward name="success" path="EXIT"/>
             </JsonPipe>
 
         </Pipeline>

--- a/src/main/configurations/Translate/Configuration_GetZaakDetailsByBsn.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDetailsByBsn.xml
@@ -35,8 +35,22 @@
                     returnedSessionKeys="Error">
                 </IbisLocalSender>
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
+            
+            <XsltPipe 
+                name="UncaughtException"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> <!-- codes: TechnicalError, TranslationError, ConfigurationError-->
+                <Param name="reason" pattern="Uncaught exception" /> 
+                <!-- <Param name="details" sessionKey="" /> -->
+                <Param name="detailsXml" type="DOMDOC" />
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
@@ -55,18 +55,15 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapZgwEnkelvoudigInformatieObjectToSingle"/>
+            <JsonPipe
+                name="JsonToXml"
+                rootElementName="ZgwEnkelvoudigInformatieObject"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
+            >
+                <Forward name="success" path="CheckForGetZaakDocumentResult" />
+                <Forward name="exception" path="EXCEPTION" />
             </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapZgwEnkelvoudigInformatieObjectToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-                >
-                <Param name="Type" value="ZgwEnkelvoudigInformatieObject"/>
-                <Forward name="success" path="CheckForGetZaakDocumentResult"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
 
             <IfPipe name="CheckForGetZaakDocumentResult"
                 xpathExpression="string-length(/ZgwEnkelvoudigInformatieObject) > 0"

--- a/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
@@ -47,7 +47,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="GetZaakDocumentByUrl" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
@@ -43,16 +43,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZaakDocumentByUrl" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapZgwEnkelvoudigInformatieObjectToSingle"/>

--- a/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
@@ -47,6 +47,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="GetZaakDocumentByUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZaakDocumentByUrl"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZaakDocumentByUrlSender" 
 					methodType="GET"
@@ -49,6 +50,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="GetZaakDocumentByUrl" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
@@ -47,12 +47,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
-                <Param name="senderPipeName" value="GetZaakDocumentByUrl" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
@@ -43,9 +43,40 @@
                 <Param name="url" sessionKey="Url"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt">
+                <Param name="Type" value="ZgwEnkelvoudigInformatieObject"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
@@ -44,16 +44,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZaakInformatieObjectenByZaak" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapZgwZaakInformatieObjectToList"/>

--- a/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
@@ -48,6 +48,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'zaakinformatieobjecten?zaak=',
+                            $zaak)">
+                    <Param name="zaak" sessionKey="ZaakUrl"/>
+                </Param>
                 <Param name="senderPipeName" value="GetZaakInformatieObjectenByZaak" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
@@ -48,8 +48,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaakinformatieobjecten?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZaakUrl"/>

--- a/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZaakInformatieObjectenByZaak"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZaakInformatieObjectenByZaakSender" 
 					methodType="GET"
@@ -54,6 +55,9 @@
                     <Param name="zaak" sessionKey="ZaakUrl"/>
                 </Param>
                 <Param name="senderPipeName" value="GetZaakInformatieObjectenByZaak" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
@@ -48,16 +48,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaakinformatieobjecten?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZaakUrl"/>
                 </Param>
-                <Param name="senderPipeName" value="GetZaakInformatieObjectenByZaak" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakInformatieObjectenByZaak.xml
@@ -44,9 +44,42 @@
                 <Param name="zaak" sessionKey="ZaakUrl"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="ZaakDocument/xsl/UnwrapZgwZaakInformatieObjectToList.xslt"
+                >
+                <Param name="List" value="ZgwZaakInformatieObjecten"/>
+                <Param name="Type" value="ZgwZaakInformatieObject"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -68,19 +101,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapZgwZaakInformatieObjectToList"/>
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapZgwZaakInformatieObjectToList"
-                styleSheetName="ZaakDocument/xsl/UnwrapZgwZaakInformatieObjectToList.xslt"
-                >
-                <Param name="List" value="ZgwZaakInformatieObjecten"/>
-                <Param name="Type" value="ZgwZaakInformatieObject"/>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
@@ -49,6 +49,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZaakUrl"/>
                 <Param name="senderPipeName" value="GetZgwZaakTypeByUrlSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
@@ -46,7 +46,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZaakUrl"/>
                 <Param name="senderPipeName" value="GetZgwZaakTypeByUrlSender" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
@@ -47,6 +47,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="ZaakUrl"/>
                 <Param name="senderPipeName" value="GetZgwZaakTypeByUrlSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
@@ -55,19 +55,15 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml"
-                storeResultInSessionKey="GetZaakTypeXmlResult">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle"/>
+            <JsonPipe
+                name="JsonToXml"
+                rootElementName="ZgwZaakType"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
+            >
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
             </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-                >
-                <Param name="Type" value="ZgwZaakType"/>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
@@ -43,16 +43,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwZaakTypeByUrlSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml"
                 storeResultInSessionKey="GetZaakTypeXmlResult">

--- a/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
@@ -46,12 +46,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZaakUrl"/>
-                <Param name="senderPipeName" value="GetZgwZaakTypeByUrlSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakTypeByUrl.xml
@@ -42,9 +42,41 @@
                 <Param name="url" sessionKey="ZaakUrl"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
+                >
+                <Param name="Type" value="ZgwZaakType" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -62,15 +94,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe
-                name="JsonToXml"
-                rootElementName="ZgwZaakType"
-                unlessSessionKey="responseType"
-                unlessValue="application/json"
-            >
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
-            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZdsZaakFromZgw.xml
+++ b/src/main/configurations/Translate/Configuration_GetZdsZaakFromZgw.xml
@@ -108,7 +108,7 @@
                     <Param name="ZgwZaakType" sessionKey="ZgwZaakType" type="DOMDOC" />
                 </IbisLocalSender>
                 <Forward name="success" path="EnrichZdsZaakWithZaakobject" />
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe
@@ -165,7 +165,7 @@
                     <Param name="ZgwZaakType" sessionKey="ZgwZaakType" type="DOMDOC" />
                 </IbisLocalSender>
                 <Forward name="success" path="EnrichZdsZaakWithRol" />
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe name="EnrichZdsZaakWithRol"
@@ -258,7 +258,7 @@
                     returnedSessionKeys="Error">
                 </IbisLocalSender>
                 <Forward name="success" path="EnrichZdsZaakWithZgwDeelzaken"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe name="EnrichZdsZaakWithZgwDeelzaken"
@@ -290,7 +290,7 @@
                     returnedSessionKeys="Error">
                 </IbisLocalSender>
                 <Forward name="success" path="EnrichZdsRelevanteAndereZaken"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe name="EnrichZdsRelevanteAndereZaken"
@@ -327,7 +327,7 @@
                 </IbisLocalSender>
                 <Param name="ZgwZaakType" sessionKey="ZgwZaakType" type="DOMDOC"/>
                 <Forward name="success" path="EnrichZdsZaakWithZdsHeeft"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe name="EnrichZdsZaakWithZdsHeeft"
@@ -338,6 +338,20 @@
                 <Param name="With" sessionKey="ZdsHeeft" type="DOMDOC"/>
                 <Forward name="success" path="EXIT"/>
                 <Forward name="exception" path="EXCEPTION"/>
+            </XsltPipe>
+            
+            <XsltPipe 
+                name="UncaughtException"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> <!-- codes: TechnicalError, TranslationError, ConfigurationError-->
+                <Param name="reason" pattern="Uncaught exception" /> 
+                <!-- <Param name="details" sessionKey="" /> -->
+                <Param name="detailsXml" type="DOMDOC" />
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
             </XsltPipe>
         </Pipeline>
     </Adapter>

--- a/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
@@ -57,8 +57,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.documenten-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.documenten-api.root-url}',
                             'enkelvoudiginformatieobjecten?identificatie=',
                             $identificatie)">
                     <Param name="identificatie" sessionKey="Identificatie"/>

--- a/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
@@ -34,7 +34,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZgwEnkelvoudigInformatieObjectByIdentificatie"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwEnkelvoudigInformatieObjectByIdentificatieSender" 
 					methodType="GET"
@@ -63,6 +64,9 @@
                     <Param name="identificatie" sessionKey="Identificatie"/>
                 </Param>
                 <Param name="senderPipeName" value="GetZgwEnkelvoudigInformatieObjectByIdentificatie" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
@@ -57,6 +57,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.documenten-api.root-url}',
+                            'enkelvoudiginformatieobjecten?identificatie=',
+                            $identificatie)">
+                    <Param name="identificatie" sessionKey="Identificatie"/>
+                </Param>
                 <Param name="senderPipeName" value="GetZgwEnkelvoudigInformatieObjectByIdentificatie" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
@@ -53,16 +53,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwEnkelvoudigInformatieObjectByIdentificatie" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="CheckForGetZgwEnkelvoudigInformatieObjectResult"/>

--- a/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
@@ -52,7 +52,7 @@
                 <Param name="identificatie" sessionKey="Identificatie"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
@@ -65,26 +65,22 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
+                <Param name="Type" value="ZgwEnkelvoudigInformatieObject"/>
+                <Forward name="success" path="JsonToXml" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwEnkelvoudigInformatieObjecten">
                 <Forward name="success" path="CheckForGetZgwEnkelvoudigInformatieObjectResult"/>
             </JsonPipe>
 
             <IfPipe name="CheckForGetZgwEnkelvoudigInformatieObjectResult"
-                xpathExpression="string-length(/root/results[1]) > 0 and count(/root/results) = 1"
+                xpathExpression="string-length(/ZgwEnkelvoudigInformatieObjecten/ZgwEnkelvoudigInformatieObject[1]) > 0 and count(/ZgwEnkelvoudigInformatieObjecten/ZgwEnkelvoudigInformatieObject) = 1"
                 >
-                <Forward name="then" path="UnwrapZgwEnkelvoudigInformatieObjectToList"/>
+                <Forward name="then" path="GetSingleZgwEnkelvoudigInformatieObjectFromList"/>
                 <Forward name="else" path="EXIT"/>
             </IfPipe>
-
-            <XsltPipe
-                name="UnwrapZgwEnkelvoudigInformatieObjectToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-                >
-                <Param name="List" value="ZgwEnkelvoudigInformatieObjecten"/>
-                <Param name="Type" value="ZgwEnkelvoudigInformatieObject"/>
-                <Forward name="success" path="GetSingleZgwEnkelvoudigInformatieObjectFromList"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
 
             <XsltPipe
                 name="GetSingleZgwEnkelvoudigInformatieObjectFromList"

--- a/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
@@ -53,39 +53,42 @@
                 <Param name="identificatie" sessionKey="Identificatie"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <!-- Error response -->
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
-                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.documenten-api.root-url}',
-                            'enkelvoudiginformatieobjecten?identificatie=',
-                            $identificatie)">
-                    <Param name="identificatie" sessionKey="Identificatie"/>
-                </Param>
-                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
-                    <Param name="response" sessionKey="response" />
-                </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
-                <Forward name="success" path="ErrorJsonToXml" />
-            </DataSonnetPipe>
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXCEPTION" /> <!-- not implemented -->
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
             
-            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
-                <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="ZgwEnkelvoudigInformatieObject"/>
-                <Forward name="success" path="JsonToXml" />
+            <!-- JSON response -->
+            <!-- <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
                 <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
+            </DataSonnetPipe> -->
 
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwEnkelvoudigInformatieObjecten">
-                <Forward name="success" path="CheckForGetZgwEnkelvoudigInformatieObjectResult"/>
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
             </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
+                >
+                <Param name="List" value="ZgwEnkelvoudigInformatieObjecten"/>
+                <Param name="Type" value="ZgwEnkelvoudigInformatieObject"/>
+                <Forward name="success" path="CheckForGetZgwEnkelvoudigInformatieObjectResult" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <IfPipe name="CheckForGetZgwEnkelvoudigInformatieObjectResult"
                 xpathExpression="string-length(/ZgwEnkelvoudigInformatieObjecten/ZgwEnkelvoudigInformatieObject[1]) > 0 and count(/ZgwEnkelvoudigInformatieObjecten/ZgwEnkelvoudigInformatieObject) = 1"
@@ -108,6 +111,27 @@
                 >
                 <Forward name="success" path="EXIT"/>
 			</XsltPipe>
+
+            <!-- Error response -->
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.documenten-api.root-url}',
+                            'enkelvoudiginformatieobjecten?identificatie=',
+                            $identificatie)">
+                    <Param name="identificatie" sessionKey="Identificatie"/>
+                </Param>
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
+                    <Param name="response" sessionKey="response" />
+                </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
+                <Forward name="success" path="EXCEPTION" />
+            </JsonPipe>
+
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwEnkelvoudigInformatieObjectByIdentificatie.xml
@@ -57,16 +57,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.documenten-api.root-url}',
                             'enkelvoudiginformatieobjecten?identificatie=',
                             $identificatie)">
                     <Param name="identificatie" sessionKey="Identificatie"/>
                 </Param>
-                <Param name="senderPipeName" value="GetZgwEnkelvoudigInformatieObjectByIdentificatie" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByOmschrijving.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByOmschrijving.xml
@@ -19,6 +19,7 @@
                 getInputFromSessionKey="ZgwZaakType"
                 storeResultInSessionKey="ZgwInformatieObjectTypen"
                 elementXPathExpression="/ZgwZaakType/informatieobjecttypen"
+                ignoreExceptions="true"
                 parallel="true"
                 maxChildThreads="20">
                 <IbisLocalSender
@@ -27,9 +28,18 @@
                     returnedSessionKeys="Error">
                     <Param name="Url" xpathExpression="/informatieobjecttypen"/>
                 </IbisLocalSender>
-                <Forward name="success" path="UnwrapZgwInformatieObjectTypenToList"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="success" path="CheckForExceptions"/>
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
+
+            <!-- only needed when parallel is set to true -->
+            <IfPipe name="CheckForExceptions"
+                xpathExpression="exists(*/result/exception)"
+                >
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Forward name="then" path="getError"/>
+                <Forward name="else" path="UnwrapZgwInformatieObjectTypenToList"/>
+            </IfPipe>
 
             <XsltPipe
                 name="UnwrapZgwInformatieObjectTypenToList"
@@ -48,6 +58,25 @@
                 <Param name="Equals" sessionKey="Omschrijving"/>
                 <Forward name="success" path="EXIT"/>
                 <Forward name="exception" path="EXCEPTION"/>
+            </XsltPipe>
+            
+            <PutInSessionPipe name="getError">
+                <Param name="Error" xpathExpression="string((//exception)[1])"/>
+                <Forward name="success" path="UncaughtException" />
+            </PutInSessionPipe>
+            
+            <XsltPipe 
+                name="UncaughtException"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> <!-- codes: TechnicalError, TranslationError, ConfigurationError-->
+                <Param name="reason" pattern="Uncaught exception" /> 
+                <!-- <Param name="details" sessionKey="" /> -->
+                <Param name="detailsXml" type="DOMDOC" />
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
             </XsltPipe>
         </Pipeline>
     </Adapter>

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
@@ -56,19 +56,10 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle"/>
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-                unlessSessionKey="responseType" unlessValue="application/json"
-                >
-                <Param name="Type" value="ZgwInformatieObjectType"/>
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwInformatieObjectType">
                 <Forward name="success" path="EXIT"/>
                 <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
+            </JsonPipe>
 
         </Pipeline>
     </Adapter>

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
@@ -26,7 +26,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZgwInformatieObjectTypeByUrl"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwInformatieObjectTypeByUrlSender" 
 					methodType="GET"
@@ -40,7 +41,8 @@
                     truststoreAuthAlias="${zaakbrug.zgw.catalogi-api.truststore.authAlias}"
                     truststoreType="${zaakbrug.zgw.catalogi-api.truststore.type}"
 				/>
-                <Param name="url" sessionKey="Url"/>
+                <!-- <Param name="url" sessionKey="Url"/> -->
+                <Param name="url" value="http://open-zaak.nginx:9001/catalogi/api/v1/informatieobjecttypen/f8aaed96-015a-4d88-a3c3-92dadc221038"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
@@ -49,6 +51,9 @@
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Param name="senderPipeName" value="GetZgwInformatieObjectTypeByUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
@@ -44,29 +44,32 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="transformErrorMessage" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
-                <Param name="senderPipeName" value="GetZgwInformatieObjectTypeByUrl" />
-                <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
 
-            <JsonPipe name="JsonToXml">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/transformErrorMessage.jsonnet" name="transformErrorMessage" storeResultInSessionKey="Error">
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
+                <Forward name="success" path="EXCEPTION" />
+            </JsonPipe>
+
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json">
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle"/>
             </JsonPipe>
 
             <XsltPipe
                 name="UnwrapOpenZaakApiEnvelopeToSingle"
                 styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
+                unlessSessionKey="responseType" unlessValue="application/json"
                 >
                 <Param name="Type" value="ZgwInformatieObjectType"/>
                 <Forward name="success" path="EXIT"/>
                 <Forward name="exception" path="EXCEPTION"/>
             </XsltPipe>
+
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
@@ -48,6 +48,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="GetZgwInformatieObjectTypeByUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
@@ -41,15 +41,14 @@
                     truststoreAuthAlias="${zaakbrug.zgw.catalogi-api.truststore.authAlias}"
                     truststoreType="${zaakbrug.zgw.catalogi-api.truststore.type}"
 				/>
-                <!-- <Param name="url" sessionKey="Url"/> -->
-                <Param name="url" value="http://open-zaak.nginx:9001/catalogi/api/v1/informatieobjecttypen/f8aaed96-015a-4d88-a3c3-92dadc221038"/>
+                <Param name="url" sessionKey="Url"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
                     <Param name="response" sessionKey="response" />

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
@@ -40,7 +40,7 @@
                     truststoreAuthAlias="${zaakbrug.zgw.catalogi-api.truststore.authAlias}"
                     truststoreType="${zaakbrug.zgw.catalogi-api.truststore.type}"
 				/>
-                <Param name="url" value="http://open-zaak.nginx:9001/catalogi/api/v1/informatieobjecttypen/badc8476-14b9-484b-93d4-f8726e0f080c"/>
+                <Param name="url" sessionKey="Url"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
@@ -40,21 +40,21 @@
                     truststoreAuthAlias="${zaakbrug.zgw.catalogi-api.truststore.authAlias}"
                     truststoreType="${zaakbrug.zgw.catalogi-api.truststore.type}"
 				/>
-                <Param name="url" sessionKey="Url"/>
+                <Param name="url" value="http://open-zaak.nginx:9001/catalogi/api/v1/informatieobjecttypen/badc8476-14b9-484b-93d4-f8726e0f080c"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="transformErrorMessage" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/transformErrorMessage.jsonnet" name="transformErrorMessage" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="senderPipeName" value="GetZgwInformatieObjectTypeByUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
-
 
             <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json">
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle"/>

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
@@ -44,9 +44,41 @@
                 <Param name="url" sessionKey="Url"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
+                >
+                <Param name="Type" value="ZgwInformatieObjectType"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -62,11 +94,6 @@
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwInformatieObjectType">
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
             </JsonPipe>
 
         </Pipeline>

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectTypeByUrl.xml
@@ -48,12 +48,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
-                <Param name="senderPipeName" value="GetZgwInformatieObjectTypeByUrl" />
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
@@ -64,6 +64,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="ZgwUnlockUrl"/>
                 <Param name="senderPipeName" value="PostUnlock" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
@@ -41,7 +41,8 @@
                 <Forward name="success" path="PostUnlock"/>
             </JsonPipe>
 
-			<SenderPipe name="PostUnlock">
+			<SenderPipe name="PostUnlock"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="PostUnlockSender" 
 					methodType="POST"
@@ -66,6 +67,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwUnlockUrl"/>
                 <Param name="senderPipeName" value="PostUnlock" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
@@ -64,7 +64,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwUnlockUrl"/>
                 <Param name="senderPipeName" value="PostUnlock" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
@@ -60,16 +60,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostUnlock" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
@@ -64,12 +64,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwUnlockUrl"/>
-                <Param name="senderPipeName" value="PostUnlock" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwInformatieObjectUnlock.xml
@@ -64,6 +64,23 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
+
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwUnlockUrl"/>

--- a/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
@@ -48,7 +48,7 @@
                 <Param name="zaak" sessionKey="ZaakUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ErrorJsonToXml" />
 			</SenderPipe>
 
@@ -61,21 +61,16 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe
-                name="JsonToXml"
-                >
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList" />
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
+                <Param name="Type" value="zgwRol"/>
+                <Forward name="success" path="JsonToXml" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwRollen">
+                <Forward name="success" path="EXIT"/>
             </JsonPipe>
 
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-                >
-                <Param name="Type" value="zgwRol" />
-                <Param name="List" value="ZgwRollen" />
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
@@ -53,6 +53,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'rollen?zaak=',
+                            $zaak)">
+                    <Param name="zaak" sessionKey="ZaakUrl" />
+                </Param>
                 <Param name="senderPipeName" value="GetZgwRolesByZaakUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
@@ -30,7 +30,7 @@
 			<SenderPipe
                 name="GetZgwRolesByZaakUrl"
                 getInputFromFixedValue="&lt;dummy/&gt;"
-                >
+                storeResultInSessionKey="response">
 				<HttpSender
 					name="GetZgwRolesByZaakUrlSender"
 					methodType="GET"
@@ -59,6 +59,9 @@
                     <Param name="zaak" sessionKey="ZaakUrl" />
                 </Param>
                 <Param name="senderPipeName" value="GetZgwRolesByZaakUrl" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
@@ -52,8 +52,8 @@
                 <Forward name="exception" path="ErrorJsonToXml" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'rollen?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZaakUrl" />

--- a/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
@@ -52,19 +52,14 @@
                 <Forward name="exception" path="ErrorJsonToXml" />
 			</SenderPipe>
 
-            <JsonPipe
-                name="ErrorJsonToXml"
-                >
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl"
-                >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwRolesByZaakUrl" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe
                 name="JsonToXml"

--- a/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
@@ -48,9 +48,42 @@
                 <Param name="zaak" sessionKey="ZaakUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ErrorJsonToXml" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>                
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
+                >
+                <Param name="Type" value="zgwRol" />
+                <Param name="List" value="ZgwRollen" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -70,16 +103,6 @@
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="zgwRol"/>
-                <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwRollen">
-                <Forward name="success" path="EXIT"/>
             </JsonPipe>
 
         </Pipeline>

--- a/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwRolesByZaakUrl.xml
@@ -52,16 +52,19 @@
                 <Forward name="exception" path="ErrorJsonToXml" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'rollen?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZaakUrl" />
                 </Param>
-                <Param name="senderPipeName" value="GetZgwRolesByZaakUrl" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
@@ -43,16 +43,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwStatusTypeByUrlSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeWrapWithType"/>

--- a/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
@@ -47,7 +47,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url" />
                 <Param name="senderPipeName" value="GetZgwStatusTypeByUrlSender" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZgwStatusTypeByUrlSender"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwStatusTypeByUrlLocalSender" 
 					methodType="GET"
@@ -49,6 +50,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url" />
                 <Param name="senderPipeName" value="GetZgwStatusTypeByUrlSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
@@ -47,6 +47,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="Url" />
                 <Param name="senderPipeName" value="GetZgwStatusTypeByUrlSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
@@ -47,12 +47,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url" />
-                <Param name="senderPipeName" value="GetZgwStatusTypeByUrlSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwStatusTypeByUrl.xml
@@ -43,9 +43,41 @@
                 <Param name="url" sessionKey="Url" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>                
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
+                >
+                <Param name="Type" value="ZgwStatusType"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -63,18 +95,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeWrapWithType"/>
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeWrapWithType"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeWrapWithType.xslt"
-                >
-                <Param name="Type" value="ZgwStatusType"/>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -56,8 +56,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaken?identificatie=',
                             $identificatie)">
                     <Param name="identificatie" sessionKey="Identificatie"/>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -51,7 +51,7 @@
                 <Param name="identificatie" sessionKey="Identificatie"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
@@ -64,19 +64,16 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-                >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
                 <Param name="Type" value="ZgwZaak"/>
-                <Param name="List" value="ZgwZaken"/>
+                <Forward name="success" path="JsonToXml" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwZaken">
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
+            </JsonPipe>
+            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -52,16 +52,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwZaakByIdentificatie" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList" />

--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -33,7 +33,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZgwZaakByIdentificatie"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwZaakByIdentificatieSender" 
 					methodType="GET"
@@ -62,6 +63,9 @@
                     <Param name="identificatie" sessionKey="Identificatie"/>
                 </Param>
                 <Param name="senderPipeName" value="GetZgwZaakByIdentificatie" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -56,6 +56,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'zaken?identificatie=',
+                            $identificatie)">
+                    <Param name="identificatie" sessionKey="Identificatie"/>
+                </Param>
                 <Param name="senderPipeName" value="GetZgwZaakByIdentificatie" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -56,16 +56,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaken?identificatie=',
                             $identificatie)">
                     <Param name="identificatie" sessionKey="Identificatie"/>
                 </Param>
-                <Param name="senderPipeName" value="GetZgwZaakByIdentificatie" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaak.xml
@@ -52,9 +52,42 @@
                 <Param name="identificatie" sessionKey="Identificatie"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>   
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
+                >
+                <Param name="List" value="ZgwZaken"/>
+                <Param name="Type" value="ZgwZaak"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -76,16 +109,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="ZgwZaak"/>
-                <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwZaken">
-                <Forward name="success" path="EXIT"/>
-            </JsonPipe>
-            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
@@ -47,6 +47,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="GetZgwZaakByUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
@@ -55,18 +55,15 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle"/>
+            <JsonPipe
+                name="JsonToXml"
+                rootElementName="ZgwZaak"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
+            >
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
             </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-                >
-                <Param name="Type" value="ZgwZaak"/>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZgwZaakByUrl"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwZaakByUrlSender" 
 					methodType="GET"
@@ -49,6 +50,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="GetZgwZaakByUrl" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
@@ -47,7 +47,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="GetZgwZaakByUrl" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
@@ -43,16 +43,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization"/>
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwZaakByUrl" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle"/>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
@@ -43,9 +43,41 @@
                 <Param name="url" sessionKey="Url"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization"/>
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>   
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
+                >
+                <Param name="Type" value="ZgwZaak"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -63,15 +95,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe
-                name="JsonToXml"
-                rootElementName="ZgwZaak"
-                unlessSessionKey="responseType"
-                unlessValue="application/json"
-            >
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
-            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakByUrl.xml
@@ -47,12 +47,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
-                <Param name="senderPipeName" value="GetZgwZaakByUrl" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
@@ -26,7 +26,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrlSender" 
 					methodType="GET"
@@ -55,6 +56,9 @@
                     <Param name="informatieobject" sessionKey="Url"/>
                 </Param>
                 <Param name="senderPipeName" value="GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
@@ -49,8 +49,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaakinformatieobjecten?informatieobject=',
                             $informatieobject)">
                     <Param name="informatieobject" sessionKey="Url"/>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
@@ -49,6 +49,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'zaakinformatieobjecten?informatieobject=',
+                            $informatieobject)">
+                    <Param name="informatieobject" sessionKey="Url"/>
+                </Param>
                 <Param name="senderPipeName" value="GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
@@ -45,16 +45,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapZgwZaakInformatieObjectToList"/>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
@@ -49,16 +49,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaakinformatieobjecten?informatieobject=',
                             $informatieobject)">
                     <Param name="informatieobject" sessionKey="Url"/>
                 </Param>
-                <Param name="senderPipeName" value="GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakInformatieObjectByEnkelvoudigInformatieObjectUrl.xml
@@ -45,9 +45,57 @@
                 <Param name="informatieobject" sessionKey="Url"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXCEPTION" /> <!-- not implemented -->
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>   
+            
+            <!-- JSON response -->
+            <!-- <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe> -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="ZaakDocument/xsl/UnwrapZgwZaakInformatieObjectToList.xslt"
+                >
+                <Param name="List" value="ZgwZaakInformatieObjecten"/>
+                <Param name="Type" value="ZgwZaakInformatieObject"/>
+                <Forward name="success" path="CheckForGetZgwZaakInformatieObjectResult" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
+
+            <IfPipe name="CheckForGetZgwZaakInformatieObjectResult"
+                xpathExpression="count(/ZgwZaakInformatieObjecten/ZgwZaakInformatieObject) = 0"
+                >
+                <Forward name="then" path="EXCEPTION"/>
+                <Forward name="else" path="GetSingleZgwZaakInformatieObjectFromList"/>
+            </IfPipe>
+
+            <XsltPipe
+                name="GetSingleZgwZaakInformatieObjectFromList"
+                styleSheetName="Common/xsl/GetSingleElementFromList.xslt"
+                >
+                <Forward name="success" path="EXIT"/>
+                <Forward name="exception" path="EXCEPTION"/>
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -69,34 +117,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapZgwZaakInformatieObjectToList"/>
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapZgwZaakInformatieObjectToList"
-                styleSheetName="ZaakDocument/xsl/UnwrapZgwZaakInformatieObjectToList.xslt"
-                >
-                <Param name="List" value="ZgwZaakInformatieObjecten"/>
-                <Param name="Type" value="ZgwZaakInformatieObject"/>
-                <Forward name="success" path="CheckForGetZgwZaakInformatieObjectResult"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
-
-            <IfPipe name="CheckForGetZgwZaakInformatieObjectResult"
-                xpathExpression="count(/ZgwZaakInformatieObjecten/ZgwZaakInformatieObject) = 0"
-                >
-                <Forward name="then" path="EXCEPTION"/>
-                <Forward name="else" path="GetSingleZgwZaakInformatieObjectFromList"/>
-            </IfPipe>
-
-            <XsltPipe
-                name="GetSingleZgwZaakInformatieObjectFromList"
-                styleSheetName="Common/xsl/GetSingleElementFromList.xslt"
-                >
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
@@ -45,7 +45,7 @@
                 <Param name="status" value="definitief"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
@@ -57,19 +57,17 @@
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList" />
-            </JsonPipe>
 
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-            >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
                 <Param name="Type" value="ZgwZaakType"/>
-                <Param name="List" value="ZgwZaakTypen"/>
+                <Forward name="success" path="JsonToXml" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwZaakTypen">
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
+            </JsonPipe>
+            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
@@ -46,16 +46,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
-            </SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+                <Forward name="exception" path="ParseNegativeHttpResult" />
+			</SenderPipe>
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwZaakTypeByIdentificatie" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList" />
             </JsonPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
@@ -26,7 +26,8 @@
             </SenderPipe>
 
             <SenderPipe name="GetZgwZaakTypeByIdentificatie"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwZaakTypeByIdentificatieSender" 
 					methodType="GET"
@@ -56,6 +57,9 @@
                             '&amp;status=', $status)">
                     <Param name="identificatie" sessionKey="ZaakTypeCode"/>
                     <Param name="status" value="definitief"/>
+                </Param>
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
                 </Param>
                 <Param name="senderPipeName" value="GetZgwZaakTypeByIdentificatie" />
                 <Forward name="success" path="ErrorJsonToXml" />

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
@@ -46,39 +46,69 @@
                 <Param name="status" value="definitief"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt">
+                <Param name="Type" value="ZgwZaakType" />
+                <Param name="List" value="ZgwZaakTypen" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
+            
+            <!-- Error response -->
+            <DataSonnetPipe
+                name="ParseNegativeHttpResult"
+                styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet"
+                getInputFromFixedValue="{}"
+                storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
                             'zaaktypen?',
                             'identificatie=', $identificatie,
                             '&amp;status=', $status)">
-                    <Param name="identificatie" sessionKey="ZaakTypeCode"/>
-                    <Param name="status" value="definitief"/>
+                    <Param name="identificatie" sessionKey="ZaakTypeCode" />
+                    <Param name="status" value="definitief" />
                 </Param>
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
-                <Param name="senderPipeName" value="GetZgwZaakTypeByIdentificatie" />
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
-            
-            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
+
+            <JsonPipe
+                name="ErrorJsonToXml"
+                rootElementName="error"
+                storeResultInSessionKey="Error">
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
-
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="ZgwZaakType"/>
-                <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwZaakTypen">
-                <Forward name="success" path="EXIT"/>
-            </JsonPipe>
-            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
@@ -50,6 +50,13 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
+                            'zaaktypen?',
+                            'identificatie=', $identificatie,
+                            '&amp;status=', $status)">
+                    <Param name="identificatie" sessionKey="ZaakTypeCode"/>
+                    <Param name="status" value="definitief"/>
+                </Param>
                 <Param name="senderPipeName" value="GetZgwZaakTypeByIdentificatie" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
@@ -50,8 +50,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.catalogi-api.root-url}',
                             'zaaktypen?',
                             'identificatie=', $identificatie,
                             '&amp;status=', $status)">

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakTypeByIdentificatie.xml
@@ -56,6 +56,7 @@
                 <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
                 <Forward name="application/xml" path="JsonResponseToXml" />
                 <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
             </SwitchPipe>
             
             <!-- JSON response -->

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
@@ -46,7 +46,7 @@
                 <Param name="zaak" sessionKey="ZgwZaakUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
@@ -59,20 +59,16 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe
-                name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-                >
-                <Param name="Type" value="ZgwZaakobject" />
-                <Param name="List" value="ZgwZaakobjecten" />
-                <Forward name="success" path="EXIT" />
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
+                <Param name="Type" value="ZgwZaakobject"/>
+                <Forward name="success" path="JsonToXml" />
                 <Forward name="exception" path="EXCEPTION" />
-            </XsltPipe>
+            </DataSonnetPipe>
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwZaakobjecten">
+                <Forward name="success" path="EXIT"/>
+            </JsonPipe>
+            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
@@ -47,22 +47,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <JsonPipe
-                name="ErrorJsonToXml"
-                >
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl"
-                >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwZaakobjectsByZaakUrl" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe
                 name="JsonToXml">

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
@@ -50,8 +50,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaakobjecten?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZgwZaakUrl" />

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
@@ -51,6 +51,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'zaakobjecten?zaak=',
+                            $zaak)">
+                    <Param name="zaak" sessionKey="ZgwZaakUrl" />
+                </Param>
                 <Param name="senderPipeName" value="GetZgwZaakobjectsByZaakUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
@@ -28,7 +28,7 @@
 			<SenderPipe
                 name="GetZgwZaakobjectsByZaakUrl"
                 getInputFromFixedValue="&lt;dummy/&gt;"
-                >
+                storeResultInSessionKey="response">
 				<HttpSender
 					name="GetZgwZaakobjectsByZaakUrlSender"
 					methodType="GET"
@@ -55,6 +55,9 @@
                             'zaakobjecten?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZgwZaakUrl" />
+                </Param>
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
                 </Param>
                 <Param name="senderPipeName" value="GetZgwZaakobjectsByZaakUrl" />
                 <Forward name="success" path="ErrorJsonToXml" />

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
@@ -50,16 +50,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaakobjecten?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZgwZaakUrl" />
                 </Param>
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
-                <Param name="senderPipeName" value="GetZgwZaakobjectsByZaakUrl" />
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZgwZaakobjectsByZaakUrl.xml
@@ -46,9 +46,42 @@
                 <Param name="zaak" sessionKey="ZgwZaakUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>   
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
+                >
+                <Param name="List" value="ZgwZaakobjecten" />
+                <Param name="Type" value="ZgwZaakobject" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -68,16 +101,6 @@
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="ZgwZaakobject"/>
-                <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwZaakobjecten">
-                <Forward name="success" path="EXIT"/>
             </JsonPipe>
             
         </Pipeline>

--- a/src/main/configurations/Translate/Configuration_PostResultaat.xml
+++ b/src/main/configurations/Translate/Configuration_PostResultaat.xml
@@ -69,16 +69,17 @@
                 <Param name="Content-Crs"  value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="ErrorJsonToXml" />
-            </SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+                <Forward name="exception" path="ParseNegativeHttpResult" />
+			</SenderPipe>
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostZgwResultaat" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_PostResultaat.xml
+++ b/src/main/configurations/Translate/Configuration_PostResultaat.xml
@@ -75,6 +75,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}resultaten" />
                 <Param name="senderPipeName" value="PostZgwResultaat" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwResultaatResult" >
+                    <Param name="PostZgwResultaatResult" sessionKey="PostZgwResultaatResult" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PostResultaat.xml
+++ b/src/main/configurations/Translate/Configuration_PostResultaat.xml
@@ -72,7 +72,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}resultaten" />
                 <Param name="senderPipeName" value="PostZgwResultaat" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwResultaatResult" >

--- a/src/main/configurations/Translate/Configuration_PostResultaat.xml
+++ b/src/main/configurations/Translate/Configuration_PostResultaat.xml
@@ -73,6 +73,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}resultaten" />
                 <Param name="senderPipeName" value="PostZgwResultaat" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_PostResultaat.xml
+++ b/src/main/configurations/Translate/Configuration_PostResultaat.xml
@@ -93,11 +93,11 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}resultaten" />
                 <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
-                    <Param name="response" sessionKey="response" />
+                    <Param name="response" sessionKey="PostZgwResultaatResult" />
                 </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Param name="senderPipeName" sessionKey="PostZgwResultaatResult" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="PostZgwResultaatResult" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="PostZgwResultaatResult" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PostResultaat.xml
+++ b/src/main/configurations/Translate/Configuration_PostResultaat.xml
@@ -68,9 +68,26 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Content-Crs"  value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="EXIT" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>   
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_PostResultaat.xml
+++ b/src/main/configurations/Translate/Configuration_PostResultaat.xml
@@ -72,12 +72,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}resultaten" />
-                <Param name="senderPipeName" value="PostZgwResultaat" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwResultaatResult" >
-                    <Param name="PostZgwResultaatResult" sessionKey="PostZgwResultaatResult" />
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
+                    <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PostZaak.xml
+++ b/src/main/configurations/Translate/Configuration_PostZaak.xml
@@ -68,22 +68,17 @@
                     <Param name="Authorization" sessionKey="Authorization" />
                 </HttpSender>
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
-            </SenderPipe>
+                <Forward name="exception" path="ParseNegativeHttpResult" />
+			</SenderPipe>
 
-            <JsonPipe
-                name="ErrorJsonToXml"
-                >
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl"
-                >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostZgwZaak" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe
                 name="JsonToXml"

--- a/src/main/configurations/Translate/Configuration_PostZaak.xml
+++ b/src/main/configurations/Translate/Configuration_PostZaak.xml
@@ -71,7 +71,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaken"/>
                 <Param name="senderPipeName" value="PostZgwZaak" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_PostZaak.xml
+++ b/src/main/configurations/Translate/Configuration_PostZaak.xml
@@ -38,7 +38,7 @@
             <SenderPipe
                 name="PostZgwZaak"
                 getInputFromSessionKey="originalMessage"
-                >
+                storeResultInSessionKey="response">
                 <Json2XmlInputValidator
                     name="ValidatePost"
                     schema="Zgw/Zaken/Model/PostZgwZaak.xsd"
@@ -74,6 +74,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaken"/>
                 <Param name="senderPipeName" value="PostZgwZaak" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PostZaak.xml
+++ b/src/main/configurations/Translate/Configuration_PostZaak.xml
@@ -82,19 +82,14 @@
 
             <JsonPipe
                 name="JsonToXml"
-                storeResultInSessionKey="PostZgwZaakResult"
-                >
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-                >
-                <Param name="Type" value="ZgwZaak" />
+                rootElementName="ZgwZaak"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
+            >
                 <Forward name="success" path="EXIT" />
                 <Forward name="exception" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
+
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_PostZaak.xml
+++ b/src/main/configurations/Translate/Configuration_PostZaak.xml
@@ -72,6 +72,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaken"/>
                 <Param name="senderPipeName" value="PostZgwZaak" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_PostZaak.xml
+++ b/src/main/configurations/Translate/Configuration_PostZaak.xml
@@ -71,12 +71,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaken"/>
-                <Param name="senderPipeName" value="PostZgwZaak" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PostZaak.xml
+++ b/src/main/configurations/Translate/Configuration_PostZaak.xml
@@ -67,9 +67,41 @@
                     <Param name="Content-Crs" value="EPSG:4326" />
                     <Param name="Authorization" sessionKey="Authorization" />
                 </HttpSender>
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>   
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
+                >
+                <Param name="Type" value="ZgwZaak" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -85,16 +117,6 @@
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <JsonPipe
-                name="JsonToXml"
-                rootElementName="ZgwZaak"
-                unlessSessionKey="responseType"
-                unlessValue="application/json"
-            >
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
             </JsonPipe>
 
         </Pipeline>

--- a/src/main/configurations/Translate/Configuration_PostZgwLock.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwLock.xml
@@ -52,7 +52,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwLockUrl"/>
                 <Param name="senderPipeName" value="PostZgwLock" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_PostZgwLock.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwLock.xml
@@ -52,6 +52,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="ZgwLockUrl"/>
                 <Param name="senderPipeName" value="PostZgwLock" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_PostZgwLock.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwLock.xml
@@ -48,16 +48,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization" sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostZgwLock" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe name="JsonToXml">
                 <Forward name="success" path="EXIT"/>

--- a/src/main/configurations/Translate/Configuration_PostZgwLock.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwLock.xml
@@ -29,7 +29,8 @@
                 <Forward name="success" path="PostZgwLock" />
             </PutInSessionPipe>
             
-            <SenderPipe name="PostZgwLock" getInputFromSessionKey="originalMessage">
+            <SenderPipe name="PostZgwLock" getInputFromSessionKey="originalMessage"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="PostZgwLockSender" 
 					methodType="POST"
@@ -54,6 +55,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwLockUrl"/>
                 <Param name="senderPipeName" value="PostZgwLock" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PostZgwLock.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwLock.xml
@@ -48,9 +48,26 @@
                 <Param name="url" sessionKey="ZgwLockUrl"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization" sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -68,9 +85,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe name="JsonToXml">
-                <Forward name="success" path="EXIT"/>
-            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_PostZgwLock.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwLock.xml
@@ -52,12 +52,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwLockUrl"/>
-                <Param name="senderPipeName" value="PostZgwLock" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
@@ -69,6 +69,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaakobjecten" />
                 <Param name="senderPipeName" value="PostZgwZaakobject" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
@@ -36,7 +36,8 @@
             </XsltPipe>
 
             <SenderPipe
-                name="PostZgwZaakobject">
+                name="PostZgwZaakobject"
+                storeResultInSessionKey="response">
                 <Json2XmlInputValidator
                     name="XmlToJson"
                     schema="CreeerZaak_LK01/xsd/ZgwZaakobject.xsd"
@@ -71,6 +72,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaakobjecten" />
                 <Param name="senderPipeName" value="PostZgwZaakobject" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
@@ -69,7 +69,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaakobjecten" />
                 <Param name="senderPipeName" value="PostZgwZaakobject" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
@@ -65,22 +65,18 @@
                 <Param name="Content-Crs"  value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <JsonPipe
-                name="ErrorJsonToXml"
-                >
-                <Forward name="success" path="buildErrorMsg" />
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="senderPipeName" value="PostZgwZaakobject" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
+                <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <XsltPipe
-                name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl"
-                >
-                <Param name="senderPipeName" value="PostZgwZaakobject" />
-                <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
@@ -69,12 +69,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaakobjecten" />
-                <Param name="senderPipeName" value="PostZgwZaakobject" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_PostZgwZaakobject.xml
@@ -65,9 +65,26 @@
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Content-Crs"  value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="EXIT" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
+++ b/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
@@ -64,16 +64,18 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PutZaakDocument" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
+
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
+++ b/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
@@ -68,7 +68,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="PutZaakDocument" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
+++ b/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
@@ -68,6 +68,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="PutZaakDocument" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
+++ b/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
@@ -45,7 +45,8 @@
                 <Forward name="success" path="PutZaakDocument" />
             </ReplacerPipe>
 
-            <SenderPipe name="PutZaakDocument">
+            <SenderPipe name="PutZaakDocument"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="PutZaakDocumentSender" 
 					methodType="PUT"
@@ -70,6 +71,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="PutZaakDocument" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
+++ b/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
@@ -64,9 +64,26 @@
                 <Param name="url" sessionKey="Url"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="EXIT" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
+++ b/src/main/configurations/Translate/Configuration_PutZgwZaakDocument.xml
@@ -68,12 +68,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
-                <Param name="senderPipeName" value="PutZaakDocument" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_RolHandler.xml
+++ b/src/main/configurations/Translate/Configuration_RolHandler.xml
@@ -45,7 +45,7 @@
                     <Param sessionKey="RolBody_1" type="DOMDOC"/>
                 </IbisLocalSender>
                 <Forward name="success" path="CallDetectRolChanges"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <ForEachChildElementPipe
@@ -60,8 +60,22 @@
                     <Param sessionKey="RolBody_1" type="DOMDOC"/>
                 </IbisLocalSender>
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
+            
+            <XsltPipe 
+                name="UncaughtException"
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                styleSheetName="Common/xsl/BuildError.xsl"
+                storeResultInSessionKey="Error">
+                <Param name="cause" sessionKey="Error" type="DOMDOC" />
+                <Param name="code" value="TechnicalError" /> <!-- codes: TechnicalError, TranslationError, ConfigurationError-->
+                <Param name="reason" pattern="Uncaught exception" /> 
+                <!-- <Param name="details" sessionKey="" /> -->
+                <Param name="detailsXml" type="DOMDOC" />
+                <Forward name="success" path="EXCEPTION" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -145,7 +145,8 @@
 
             <ForEachChildElementPipe name="ZgwResultatenIterator"
                 getInputFromSessionKey="GetResultatenByZaakUrlResult"
-                elementXPathExpression="/root/results">
+                elementXPathExpression="/root/results"
+                storeResultInSessionKey="response">
                 <HttpSender
                     name="DeleteZaakResultaatSender" 
 					methodType="DELETE"
@@ -170,6 +171,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_1" storeResultInSessionKey="Error">
                     <Param name="url" xpathExpression="results/url"/>
                 <Param name="senderPipeName" value="ZgwResultatenIterator" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml_1" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -168,6 +168,7 @@
 			</ForEachChildElementPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_1" storeResultInSessionKey="Error">
+                    <Param name="url" xpathExpression="results/url"/>
                 <Param name="senderPipeName" value="ZgwResultatenIterator" />
                 <Forward name="success" path="ErrorJsonToXml_1" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -168,7 +168,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult_1" />
 			</ForEachChildElementPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_1" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_1" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                     <Param name="url" xpathExpression="results/url"/>
                 <Param name="senderPipeName" value="ZgwResultatenIterator" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -164,16 +164,21 @@
                     <Param name="Authorization"  sessionKey="Authorization" />
                 </HttpSender>
                 <Forward name="success" path="CallPostResultaat_1"/>
-                <Forward name="exception" path="ErrorJsonToXml" />
-            </ForEachChildElementPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+                <Forward name="exception" path="ParseNegativeHttpResult_1" />
+			</ForEachChildElementPipe>
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_1" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="ZgwResultatenIterator" />
+                <Forward name="success" path="ErrorJsonToXml_1" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml_1" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
+                <Forward name="success" path="EXCEPTION" />
+            </JsonPipe>
 
             <SenderPipe
                 name="CallPostResultaat_1"

--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -169,7 +169,7 @@
 			</ForEachChildElementPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_1" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
-                    <Param name="url" xpathExpression="results/url"/>
+                <Param name="url" sessionKey="GetResultatenByZaakUrlResult" xpathExpression="results/url"/>
                 <Param name="senderPipeName" value="ZgwResultatenIterator" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
                     <Param name="response" sessionKey="response" />

--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -168,12 +168,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult_1" />
 			</ForEachChildElementPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_1" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="GetResultatenByZaakUrlResult" xpathExpression="results/url"/>
-                <Param name="senderPipeName" value="ZgwResultatenIterator" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml_1" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -177,12 +177,8 @@
                 <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
                 <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
                 <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
-                <Forward name="success" path="ErrorJsonToXml_1" />
+                <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
-            
-            <JsonPipe name="ErrorJsonToXml_1" rootElementName="error" storeResultInSessionKey="Error" >
-                <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />

--- a/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
@@ -40,6 +40,9 @@
                             $identificatie)">
 					<Param name="identificatie" xpathExpression="root/zakLv01/gelijk/identificatie"/>
                 </Param>
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$zaakTypeJson" >
+                    <Param name="zaakTypeJson" sessionKey="zaakTypeJson" />
+                </Param>
                 <Param name="senderPipeName" value="getZgwZaakByIdentificatie" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
@@ -72,6 +75,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_2" storeResultInSessionKey="Error">
 				<Param name="url" sessionKey="zaakXml" xpathExpression="results/zaaktype"/>
                 <Param name="senderPipeName" value="getZaakTypeByUrl" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$zaakTypeJson" >
+                    <Param name="zaakTypeJson" sessionKey="zaakTypeJson" />
+                </Param>
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
             
@@ -110,6 +116,9 @@
                             'rollen?zaak=',
                             $zaak)">
 					<Param name="zaak" sessionKey="zaakXml" xpathExpression="results/url"/>
+                </Param>
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$rollenJson" >
+                    <Param name="rollenJson" sessionKey="rollenJson" />
                 </Param>
                 <Param name="senderPipeName" value="getRollenByUrl" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />

--- a/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
@@ -34,8 +34,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaken?identificatie=',
                             $identificatie)">
 					<Param name="identificatie" xpathExpression="root/zakLv01/gelijk/identificatie"/>
@@ -72,7 +72,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult_2" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_2" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_2" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
 				<Param name="url" sessionKey="zaakXml" xpathExpression="results/zaaktype"/>
                 <Param name="senderPipeName" value="getZaakTypeByUrl" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$zaakTypeJson" >
@@ -111,8 +111,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult_3" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_3" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_3" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'rollen?zaak=',
                             $zaak)">
 					<Param name="zaak" sessionKey="zaakXml" xpathExpression="results/url"/>

--- a/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
@@ -31,16 +31,17 @@
 						<Param name="token" sessionKey="token" />
 					</Param>
 				</HttpSender>
-				<Forward name="exception" path="ErrorJsonToXml_1" />
+                <Forward name="exception" path="ParseNegativeHttpResult_1" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml_1">
-                <Forward name="success" path="buildErrorMsg_1" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg_1"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_1" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="getZgwZaakByIdentificatie" />
+                <Forward name="success" path="getZgwZaakByIdentificatie" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml_1" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
 			<JsonPipe name="toZaakXml"/>
 
@@ -60,16 +61,17 @@
 						<Param name="token" sessionKey="token" />
 					</Param>
 				</HttpSender>
-				<Forward name="exception" path="ErrorJsonToXml_2" />
+                <Forward name="exception" path="ParseNegativeHttpResult_2" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml_2">
-                <Forward name="success" path="buildErrorMsg_2" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg_2"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_2" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="getZaakTypeByUrl" />
+                <Forward name="success" path="getZgwZaakByIdentificatie" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml_2" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
 			<JsonPipe name="toZaakTypeXml"/>
 
@@ -94,16 +96,17 @@
 						<Param name="token" sessionKey="token" />
 					</Param>
 				</HttpSender>
-				<Forward name="exception" path="ErrorJsonToXml_3" />
+                <Forward name="exception" path="ParseNegativeHttpResult_3" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml_3">
-                <Forward name="success" path="buildErrorMsg_3" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg_3"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_3" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="getRollenByUrl" />
+                <Forward name="success" path="getZgwZaakByIdentificatie" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml_3" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
 			<JsonPipe name="toRollenXml"/>
 

--- a/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
@@ -31,15 +31,20 @@
 						<Param name="token" sessionKey="token" />
 					</Param>
 				</HttpSender>
-                <Forward name="exception" path="ParseNegativeHttpResult_1" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_1" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'zaken?identificatie=',
+                            $identificatie)">
+					<Param name="identificatie" xpathExpression="root/zakLv01/gelijk/identificatie"/>
+                </Param>
                 <Param name="senderPipeName" value="getZgwZaakByIdentificatie" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
             
-            <JsonPipe name="ErrorJsonToXml_1" rootElementName="error" storeResultInSessionKey="Error" >
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
@@ -65,6 +70,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_2" storeResultInSessionKey="Error">
+				<Param name="url" sessionKey="zaakXml" xpathExpression="results/zaaktype"/>
                 <Param name="senderPipeName" value="getZaakTypeByUrl" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
@@ -100,6 +106,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_3" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'rollen?zaak=',
+                            $zaak)">
+					<Param name="zaak" sessionKey="zaakXml" xpathExpression="results/url"/>
+                </Param>
                 <Param name="senderPipeName" value="getRollenByUrl" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
@@ -42,11 +42,11 @@
 					<Param name="identificatie" xpathExpression="root/zakLv01/gelijk/identificatie"/>
                 </Param>
                 <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
-                    <Param name="response" sessionKey="response" />
+                    <Param name="response" sessionKey="zaakTypeJson" />
                 </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Param name="senderPipeName" sessionKey="zaakTypeJson" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="zaakTypeJson" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="zaakTypeJson" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
             
@@ -79,11 +79,11 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_2" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
 				<Param name="url" sessionKey="zaakXml" xpathExpression="results/zaaktype"/>
                 <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
-                    <Param name="response" sessionKey="response" />
+                    <Param name="response" sessionKey="zaakTypeJson" />
                 </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Param name="senderPipeName" sessionKey="zaakTypeJson" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="zaakTypeJson" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="zaakTypeJson" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
             
@@ -125,11 +125,11 @@
 					<Param name="zaak" sessionKey="zaakXml" xpathExpression="results/url"/>
                 </Param>
                 <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
-                    <Param name="response" sessionKey="response" />
+                    <Param name="response" sessionKey="rollenJson" />
                 </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Param name="senderPipeName" sessionKey="rollenJson" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="rollenJson" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="rollenJson" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_Translate_GeefZaakdetails_Lv01.xml
@@ -34,16 +34,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'zaken?identificatie=',
                             $identificatie)">
 					<Param name="identificatie" xpathExpression="root/zakLv01/gelijk/identificatie"/>
                 </Param>
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$zaakTypeJson" >
-                    <Param name="zaakTypeJson" sessionKey="zaakTypeJson" />
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
+                    <Param name="response" sessionKey="response" />
                 </Param>
-                <Param name="senderPipeName" value="getZgwZaakByIdentificatie" />
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
             
@@ -72,12 +75,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult_2" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_2" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
 				<Param name="url" sessionKey="zaakXml" xpathExpression="results/zaaktype"/>
-                <Param name="senderPipeName" value="getZaakTypeByUrl" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$zaakTypeJson" >
-                    <Param name="zaakTypeJson" sessionKey="zaakTypeJson" />
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
+                    <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
             
@@ -111,16 +117,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult_3" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult_3" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'rollen?zaak=',
                             $zaak)">
 					<Param name="zaak" sessionKey="zaakXml" xpathExpression="results/url"/>
                 </Param>
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$rollenJson" >
-                    <Param name="rollenJson" sessionKey="rollenJson" />
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
+                    <Param name="response" sessionKey="response" />
                 </Param>
-                <Param name="senderPipeName" value="getRollenByUrl" />
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="getZgwZaakByIdentificatie" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_UpdateZaak_LK01.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZaak_LK01.xml
@@ -243,7 +243,7 @@
                     <Param name="ZaakType" sessionKey="GetZgwZaaktypeByUrlResult" xpathExpression="/ZgwZaakType/identificatie" />
                 </IbisLocalSender>
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToZgwZaakobjectenList" />
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe
@@ -269,7 +269,7 @@
                     <Param name="ZaakType" sessionKey="GetZgwZaaktypeByUrlResult" type="DOMDOC" />
                 </IbisLocalSender>
                 <Forward name="success" path="CallDetectZaakobjectChanges"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <ForEachChildElementPipe
@@ -286,7 +286,7 @@
                     <Param name="ZaakType" sessionKey="GetZgwZaaktypeByUrlResult" type="DOMDOC" />
                 </IbisLocalSender>
                 <Forward name="success" path="SelectZdsRolesFromZdsWasZaak"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe
@@ -332,7 +332,7 @@
                     <Param name="RolMapping" sessionKey="GlobalConfig" type="DOMDOC" />
                 </IbisLocalSender>
                 <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToZgwRollenList" />
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe
@@ -372,7 +372,7 @@
                     <Param name="RolMapping" sessionKey="GlobalConfig" type="DOMDOC" />
                 </IbisLocalSender>
                 <Forward name="success" path="CallDetectRolChanges"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <ForEachChildElementPipe
@@ -394,7 +394,7 @@
                     <Param name="RolMapping" sessionKey="GlobalConfig" type="DOMDOC" />
                 </IbisLocalSender>
                 <Forward name="success" path="WrapZdsWordtZaak"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe
@@ -489,7 +489,7 @@
                     <Param name="DeelzaakIdentificatie" xpathExpression="heeftAlsDeelzaak/gerelateerde/identificatie" />
                 </IbisLocalSender>
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION" />
+                <Forward name="exception" path="UncaughtException" />
             </ForEachChildElementPipe>
 
             <XsltPipe 

--- a/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
@@ -88,7 +88,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwZaakobjectUrlForUpdate" />
                 <Param name="senderPipeName" value="PostZgwZaakobject" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
@@ -57,7 +57,8 @@
             </XsltPipe>
 
             <SenderPipe
-                name="UpdateZgwZaakobject">
+                name="UpdateZgwZaakobject"
+                storeResultInSessionKey="response">
                 <Json2XmlInputValidator
                     name="XmlToJson"
                     schema="CreeerZaak_LK01/xsd/ZgwZaakobject.xsd"
@@ -90,6 +91,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwZaakobjectUrlForUpdate" />
                 <Param name="senderPipeName" value="PostZgwZaakobject" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
@@ -84,20 +84,17 @@
                 <Param name="Content-Crs"  value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="ErrorJsonToXml" />
-            </SenderPipe>
+                <Forward name="exception" path="ParseNegativeHttpResult" />
+			</SenderPipe>
 
-            <JsonPipe
-                name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostZgwZaakobject" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
@@ -88,6 +88,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="ZgwZaakobjectUrlForUpdate" />
                 <Param name="senderPipeName" value="PostZgwZaakobject" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
@@ -88,12 +88,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="ZgwZaakobjectUrlForUpdate" />
-                <Param name="senderPipeName" value="PostZgwZaakobject" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
+++ b/src/main/configurations/Translate/Configuration_UpdateZgwZaakobject.xml
@@ -84,9 +84,26 @@
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Content-Crs"  value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="EXIT" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
@@ -27,7 +27,7 @@
             <SenderPipe
                 name="DeleteZgwZaakSender"
                 getInputFromFixedValue="&lt;dummy/&gt;"
-                >
+                storeResultInSessionKey="response">
                 <HttpSender
                     name="DeleteZgwZaakHttpSender"
                     methodType="DELETE"
@@ -56,6 +56,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="url" />
                 <Param name="senderPipeName" value="DeleteZgwZaakSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
@@ -54,6 +54,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="url" />
                 <Param name="senderPipeName" value="DeleteZgwZaakSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
@@ -50,22 +50,17 @@
                     <Param name="Authorization" sessionKey="Authorization"/>
                 </HttpSender>
                 <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="ErrorJsonToXml" />
-            </SenderPipe> 
+                <Forward name="exception" path="ParseNegativeHttpResult" />
+			</SenderPipe>
 
-            <JsonPipe
-                name="ErrorJsonToXml"
-                >
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl"
-                >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="DeleteZgwZaakSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>  
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
@@ -53,7 +53,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="url" />
                 <Param name="senderPipeName" value="DeleteZgwZaakSender" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
@@ -49,9 +49,26 @@
                     <Param name="Content-Crs" value="EPSG:4326" />
                     <Param name="Authorization" sessionKey="Authorization"/>
                 </HttpSender>
-                <Forward name="success" path="EXIT" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_DeleteZgwZaak.xml
@@ -53,12 +53,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="url" />
-                <Param name="senderPipeName" value="DeleteZgwZaakSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
@@ -51,6 +51,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="url" />
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
@@ -47,18 +47,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Authorization" sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
-            </SenderPipe>
+                <Forward name="exception" path="ParseNegativeHttpResult" />
+			</SenderPipe>
 
-
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe
                 name="JsonToXml">

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
@@ -60,18 +60,14 @@
             </JsonPipe>
 
             <JsonPipe
-                name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle" />
+                name="JsonToXml"
+                rootElementName="ZgwResultaat"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
+            >
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
             </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-                >
-                <Param name="Type" value="ZgwResultaat"/>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
@@ -28,7 +28,8 @@
 
             <SenderPipe
                 name="GetZgwResultaatByUrlSender"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
                 <HttpSender
                     name="GetZgwResultaatByUrlHttpSender"
                     methodType="GET"
@@ -53,6 +54,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="url" />
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
@@ -51,7 +51,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="url" />
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
@@ -47,9 +47,40 @@
                 <Param name="url" sessionKey="url" />
                 <Param name="Accept-Crs" value="EPSG:4326" />
                 <Param name="Authorization" sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt">
+                <Param name="Type" value="ZgwResultaat" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -66,16 +97,7 @@
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
-
-            <JsonPipe
-                name="JsonToXml"
-                rootElementName="ZgwResultaat"
-                unlessSessionKey="responseType"
-                unlessValue="application/json"
-            >
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
-            </JsonPipe>
+            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatByUrl.xml
@@ -51,12 +51,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="url" />
-                <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
@@ -45,16 +45,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwResultaatTypeByUrlSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe 
                 name="JsonToXml">

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
@@ -26,7 +26,8 @@
 
 			<SenderPipe 
                 name="GetZgwResultaatTypeByUrlSender"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwResultaatTypeByUrlHttpSender" 
 					methodType="GET"
@@ -51,6 +52,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="url" />
                 <Param name="senderPipeName" value="GetZgwResultaatTypeByUrlSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
@@ -49,6 +49,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="url" />
                 <Param name="senderPipeName" value="GetZgwResultaatTypeByUrlSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
@@ -49,7 +49,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="url" />
                 <Param name="senderPipeName" value="GetZgwResultaatTypeByUrlSender" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
@@ -57,19 +57,15 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe 
-                name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle"/>
+            <JsonPipe
+                name="JsonToXml"
+                rootElementName="ZgwResultaatType"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
+            >
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
             </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-                >
-                <Param name="Type" value="ZgwResultaatType"/>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
@@ -45,9 +45,40 @@
                 <Param name="url" sessionKey="url" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt">
+                <Param name="Type" value="ZgwResultaatType" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -65,15 +96,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe
-                name="JsonToXml"
-                rootElementName="ZgwResultaatType"
-                unlessSessionKey="responseType"
-                unlessValue="application/json"
-            >
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
-            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwResultaatTypeByUrl.xml
@@ -49,12 +49,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="url" />
-                <Param name="senderPipeName" value="GetZgwResultaatTypeByUrlSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
@@ -45,16 +45,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe 
                 name="JsonToXml">

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
@@ -49,7 +49,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url" />
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
@@ -26,7 +26,8 @@
 
 			<SenderPipe 
                 name="GetZgwRolTypeByUrlSender"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwRolTypeByUrlHttpSender" 
 					methodType="GET"
@@ -51,6 +52,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url" />
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
@@ -57,19 +57,15 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe 
-                name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle"/>
+            <JsonPipe
+                name="JsonToXml"
+                rootElementName="ZgwRolType"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
+            >
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
             </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-                >
-                <Param name="Type" value="ZgwRolType"/>
-                <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
@@ -49,6 +49,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="Url" />
                 <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
@@ -49,12 +49,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url" />
-                <Param name="senderPipeName" value="GetZgwRolTypeByUrlSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByUrl.xml
@@ -45,9 +45,40 @@
                 <Param name="url" sessionKey="Url" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt">
+                <Param name="Type" value="ZgwRolType" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -65,15 +96,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe
-                name="JsonToXml"
-                rootElementName="ZgwRolType"
-                unlessSessionKey="responseType"
-                unlessValue="application/json"
-            >
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
-            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
@@ -50,7 +50,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" xpathExpression="concat('{zaakbrug.zgw.catalogi-api.root-url}',
                             'roltypen?zaaktype=',
                             $zaaktype)">

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
@@ -46,7 +46,7 @@
                 <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
@@ -59,21 +59,16 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe 
-                name="JsonToXml"
-                >
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList"/>
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-                >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
                 <Param name="Type" value="ZgwRolType"/>
-                <Param name="List" value="ZgwRolTypen"/>
+                <Forward name="success" path="JsonToXml" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwRolTypen">
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
+            </JsonPipe>
+            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
@@ -47,16 +47,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwRolTypeByZaakTypeSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe 
                 name="JsonToXml"

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
@@ -51,6 +51,11 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('{zaakbrug.zgw.catalogi-api.root-url}',
+                            'roltypen?zaaktype=',
+                            $zaaktype)">
+                    <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
+                </Param>
                 <Param name="senderPipeName" value="GetZgwRolTypeByZaakTypeSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
@@ -27,7 +27,7 @@
 			<SenderPipe 
                 name="GetZgwRolTypeByZaakTypeSender" 
                 getInputFromFixedValue="&lt;dummy/&gt;"
-                >
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwRolTypeByZaakTypeHttpSender" 
 					methodType="GET"
@@ -57,6 +57,9 @@
                     <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 </Param>
                 <Param name="senderPipeName" value="GetZgwRolTypeByZaakTypeSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
@@ -50,16 +50,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" xpathExpression="concat('{zaakbrug.zgw.catalogi-api.root-url}',
                             'roltypen?zaaktype=',
                             $zaaktype)">
                     <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 </Param>
-                <Param name="senderPipeName" value="GetZgwRolTypeByZaakTypeSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwRolTypeByZaakType.xml
@@ -46,9 +46,41 @@
                 <Param name="zaaktype" sessionKey="ZaakTypeUrl" />
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt">
+                <Param name="Type" value="ZgwRolType"/>
+                <Param name="List" value="ZgwRolTypen"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -68,16 +100,6 @@
             
             <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </JsonPipe>
-
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="ZgwRolType"/>
-                <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwRolTypen">
-                <Forward name="success" path="EXIT"/>
             </JsonPipe>
             
         </Pipeline>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
@@ -48,6 +48,12 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+                            'statussen?zaak=',
+                            $zaak)">
+                    <Param name="zaak" sessionKey="ZaakUrl"/>       
+                </Param>
+                <Param name="zaak" sessionKey="ZaakUrl"/>
                 <Param name="senderPipeName" value="GetZgwStatusByZaakUrlSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
@@ -43,7 +43,7 @@
                 <Param name="zaak" sessionKey="ZaakUrl"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="unwrapJsonEnvelope" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
@@ -56,20 +56,16 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <JsonPipe 
-                name="JsonToXml">
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList"/>
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToList"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt"
-                >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
                 <Param name="Type" value="ZgwStatus"/>
-                <Param name="List" value="ZgwStatussen"/>
+                <Forward name="success" path="JsonToXml" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwStatussen">
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="EXCEPTION"/>
-            </XsltPipe>
+            </JsonPipe>
+            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
@@ -48,8 +48,8 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
-                <Param name="url" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
+                <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'statussen?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZaakUrl"/>       

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
@@ -25,7 +25,8 @@
             </SenderPipe>
 
 			<SenderPipe name="GetZgwStatusByZaakUrlSender"
-                getInputFromFixedValue="&lt;dummy/&gt;">
+                getInputFromFixedValue="&lt;dummy/&gt;"
+                storeResultInSessionKey="response">
 				<HttpSender 
 					name="GetZgwStatusByZaakUrlHttpSender" 
 					methodType="GET"
@@ -55,6 +56,9 @@
                 </Param>
                 <Param name="zaak" sessionKey="ZaakUrl"/>
                 <Param name="senderPipeName" value="GetZgwStatusByZaakUrlSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
@@ -44,16 +44,17 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="GetZgwStatusByZaakUrlSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
 
             <JsonPipe 
                 name="JsonToXml">

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
@@ -48,17 +48,19 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="&lt;dummy/&gt;" xpathExpression="concat('${zaakbrug.zgw.zaken-api.root-url}',
                             'statussen?zaak=',
                             $zaak)">
                     <Param name="zaak" sessionKey="ZaakUrl"/>       
                 </Param>
-                <Param name="zaak" sessionKey="ZaakUrl"/>
-                <Param name="senderPipeName" value="GetZgwStatusByZaakUrlSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_GetZgwStatusByZaakUrl.xml
@@ -44,9 +44,41 @@
                 <Param name="zaak" sessionKey="ZaakUrl"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="unwrapJsonEnvelope" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToList_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToList_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToList.xslt">
+                <Param name="Type" value="ZgwStatus"/>
+                <Param name="List" value="ZgwStatussen"/>
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -68,16 +100,6 @@
                 <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet" name="unwrapJsonEnvelope">
-                <Param name="Type" value="ZgwStatus"/>
-                <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="EXCEPTION" />
-            </DataSonnetPipe>
-
-            <JsonPipe name="JsonToXml" unlessSessionKey="responseType" unlessValue="application/json" rootElementName="ZgwStatussen">
-                <Forward name="success" path="EXIT"/>
-            </JsonPipe>
-            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
@@ -51,6 +51,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" value="${zaakbrug.zgw.documenten-api.root-url}documentnummer_reserveren"/>
                 <Param name="senderPipeName" value="PostZgwStatus" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
@@ -50,7 +50,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.documenten-api.root-url}documentnummer_reserveren"/>
                 <Param name="senderPipeName" value="PostZgwStatus" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwDocumentnummer_reserverenResult" >

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
@@ -53,6 +53,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.documenten-api.root-url}documentnummer_reserveren"/>
                 <Param name="senderPipeName" value="PostZgwStatus" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwDocumentnummer_reserverenResult" >
+                    <Param name="PostZgwDocumentnummer_reserverenResult" sessionKey="PostZgwDocumentnummer_reserverenResult" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
@@ -47,16 +47,17 @@
                 <Param name="Content-Crs"  value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostZgwStatus" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
@@ -46,9 +46,26 @@
                 <Param name="Accept-Crs" value="EPSG:4326"/>
                 <Param name="Content-Crs"  value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
-                <Forward name="success" path="EXIT" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
@@ -71,11 +71,11 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.documenten-api.root-url}documentnummer_reserveren"/>
                 <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
-                    <Param name="response" sessionKey="response" />
+                    <Param name="response" sessionKey="PostZgwDocumentnummer_reserverenResult" />
                 </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Param name="senderPipeName" sessionKey="PostZgwDocumentnummer_reserverenResult" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="PostZgwDocumentnummer_reserverenResult" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="PostZgwDocumentnummer_reserverenResult" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwDocumentnummer_reserveren.xml
@@ -50,12 +50,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.documenten-api.root-url}documentnummer_reserveren"/>
-                <Param name="senderPipeName" value="PostZgwStatus" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwDocumentnummer_reserverenResult" >
-                    <Param name="PostZgwDocumentnummer_reserverenResult" sessionKey="PostZgwDocumentnummer_reserverenResult" />
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
+                    <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
@@ -70,22 +70,17 @@
                 <Param name="Content-Crs"  value="EPSG:4326" />
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <JsonPipe
-                name="ErrorJsonToXml"
-                >
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl"
-                >
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostZgwRol" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
@@ -74,6 +74,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}rollen" />
                 <Param name="senderPipeName" value="PostZgwRol" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
@@ -73,7 +73,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}rollen" />
                 <Param name="senderPipeName" value="PostZgwRol" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwRolResult" >

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
@@ -76,6 +76,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}rollen" />
                 <Param name="senderPipeName" value="PostZgwRol" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwRolResult" >
+                    <Param name="PostZgwRolResult" sessionKey="PostZgwRolResult" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
@@ -73,12 +73,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}rollen" />
-                <Param name="senderPipeName" value="PostZgwRol" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwRolResult" >
-                    <Param name="PostZgwRolResult" sessionKey="PostZgwRolResult" />
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
+                    <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
@@ -94,11 +94,11 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}rollen" />
                 <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
-                    <Param name="response" sessionKey="response" />
+                    <Param name="response" sessionKey="PostZgwRolResult" />
                 </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Param name="senderPipeName" sessionKey="PostZgwRolResult" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="PostZgwRolResult" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="PostZgwRolResult" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwRol.xml
@@ -72,6 +72,23 @@
                 <Forward name="success" path="EXIT" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
@@ -61,7 +61,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}statussen"/>
                 <Param name="senderPipeName" value="PostZgwStatus" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwStatusResult" >

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
@@ -58,16 +58,17 @@
                 <Param name="Content-Crs"  value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostZgwStatus" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
@@ -64,6 +64,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}statussen"/>
                 <Param name="senderPipeName" value="PostZgwStatus" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwStatusResult" >
+                    <Param name="PostZgwStatusResult" sessionKey="PostZgwStatusResult" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
@@ -62,6 +62,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}statussen"/>
                 <Param name="senderPipeName" value="PostZgwStatus" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
@@ -60,6 +60,23 @@
                 <Forward name="success" path="EXIT" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
@@ -82,11 +82,11 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}statussen"/>
                 <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
-                    <Param name="response" sessionKey="response" />
+                    <Param name="response" sessionKey="PostZgwStatusResult" />
                 </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Param name="senderPipeName" sessionKey="PostZgwStatusResult" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="PostZgwStatusResult" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="PostZgwStatusResult" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwStatus.xml
@@ -61,12 +61,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}statussen"/>
-                <Param name="senderPipeName" value="PostZgwStatus" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwStatusResult" >
-                    <Param name="PostZgwStatusResult" sessionKey="PostZgwStatusResult" />
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
+                    <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
@@ -93,18 +93,13 @@
 
             <JsonPipe
                 name="JsonToXml"
-                >
-                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle" />
-            </JsonPipe>
-
-            <XsltPipe
-                name="UnwrapOpenZaakApiEnvelopeToSingle"
-                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt"
-                >
-                <Param name="Type" value="ZgwEnkelvoudigInformatieObject" />
+                rootElementName="ZgwEnkelvoudigInformatieObject"
+                unlessSessionKey="responseType"
+                unlessValue="application/json"
+            >
                 <Forward name="success" path="EXIT" />
                 <Forward name="exception" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
@@ -77,6 +77,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" value="${zaakbrug.zgw.documenten-api.root-url}enkelvoudiginformatieobjecten"/>
                 <Param name="senderPipeName" value="PostZgwEnkelvoudigInformatieObjectSender" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
@@ -73,11 +73,16 @@
                     <Param name="Authorization"  sessionKey="Authorization" />
                 </HttpSender>
                 <Forward name="success" path="JsonToXml" />
-                <Forward name="exception" path="ErrorJsonToXml" />
-            </SenderPipe>
+                <Forward name="exception" path="ParseNegativeHttpResult" />
+			</SenderPipe>
 
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="senderPipeName" value="PostZgwEnkelvoudigInformatieObjectSender" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
+                <Forward name="success" path="EXCEPTION" />
             </JsonPipe>
 
             <XsltPipe name="buildErrorMsg"

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
@@ -52,7 +52,8 @@
                 <Forward name="success" path="PostZgwEnkelvoudigInformatieObjectSender" />
             </ReplacerPipe>           
 
-            <SenderPipe name="PostZgwEnkelvoudigInformatieObjectSender">
+            <SenderPipe name="PostZgwEnkelvoudigInformatieObjectSender"
+                storeResultInSessionKey="response">
                 <HttpSender name="PostZgwEnkelvoudigInformatieObjectHttpSender"
                     methodType="POST"
                     headersParams="Authorization,Accept-Crs,Content-Crs,Accept"
@@ -79,6 +80,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.documenten-api.root-url}enkelvoudiginformatieobjecten"/>
                 <Param name="senderPipeName" value="PostZgwEnkelvoudigInformatieObjectSender" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
@@ -77,7 +77,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.documenten-api.root-url}enkelvoudiginformatieobjecten"/>
                 <Param name="senderPipeName" value="PostZgwEnkelvoudigInformatieObjectSender" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
@@ -73,9 +73,40 @@
                     <Param name="Content-Crs" value="EPSG:4326" />
                     <Param name="Authorization"  sessionKey="Authorization" />
                 </HttpSender>
-                <Forward name="success" path="JsonToXml" />
+                <Forward name="success" path="ResponseTypeSwitch" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="UnwrapOpenZaakApiEnvelope_Json" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="JsonResponseToXml" />
+                <Forward name="empty" path="JsonResponseToXml" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+            <DataSonnetPipe
+                name="UnwrapOpenZaakApiEnvelope_Json"
+                styleSheetName="Common/jsonnet/unwrapJsonEnvelope.jsonnet">
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </DataSonnetPipe>
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="UnwrapOpenZaakApiEnvelopeToSingle_Xml" />
+            </JsonPipe>
+
+            <XsltPipe
+                name="UnwrapOpenZaakApiEnvelopeToSingle_Xml"
+                styleSheetName="Common/xsl/UnwrapOpenZaakApiEnvelopeToSingle.xslt">
+                <Param name="Type" value="ZgwEnkelvoudigInformatieObject" />
+                <Forward name="success" path="EXIT" />
+                <Forward name="exception" path="EXCEPTION" />
+            </XsltPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
@@ -98,16 +129,7 @@
                 <Param name="senderPipeName" value="PostZgwEnkelvoudigInformatieObjectSender" />
                 <Forward name="success" path="EXCEPTION" />
             </XsltPipe>
-
-            <JsonPipe
-                name="JsonToXml"
-                rootElementName="ZgwEnkelvoudigInformatieObject"
-                unlessSessionKey="responseType"
-                unlessValue="application/json"
-            >
-                <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="EXCEPTION" />
-            </JsonPipe>
+            
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaakInformatieObject.xml
@@ -77,12 +77,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.documenten-api.root-url}enkelvoudiginformatieobjecten"/>
-                <Param name="senderPipeName" value="PostZgwEnkelvoudigInformatieObjectSender" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
@@ -53,6 +53,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaaknummer_reserveren"/>
                 <Param name="senderPipeName" value="PostZgwStatus" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwZaaknummer_reserverenResult" >
+                    <Param name="PostZgwZaaknummer_reserverenResult" sessionKey="PostZgwZaaknummer_reserverenResult" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
@@ -50,7 +50,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaaknummer_reserveren"/>
                 <Param name="senderPipeName" value="PostZgwStatus" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwZaaknummer_reserverenResult" >

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
@@ -47,16 +47,17 @@
                 <Param name="Content-Crs"  value="EPSG:4326"/>
                 <Param name="Authorization"  sessionKey="Authorization" />
                 <Forward name="success" path="EXIT" />
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="PostZgwStatus" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
@@ -51,6 +51,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaaknummer_reserveren"/>
                 <Param name="senderPipeName" value="PostZgwStatus" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
@@ -50,12 +50,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaaknummer_reserveren"/>
-                <Param name="senderPipeName" value="PostZgwStatus" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$PostZgwZaaknummer_reserverenResult" >
-                    <Param name="PostZgwZaaknummer_reserverenResult" sessionKey="PostZgwZaaknummer_reserverenResult" />
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
+                    <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
@@ -49,6 +49,23 @@
                 <Forward name="success" path="EXIT" />
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">

--- a/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_PostZgwZaaknummer_reserveren.xml
@@ -71,11 +71,11 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" value="${zaakbrug.zgw.zaken-api.root-url}zaaknummer_reserveren"/>
                 <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
-                    <Param name="response" sessionKey="response" />
+                    <Param name="response" sessionKey="PostZgwZaaknummer_reserverenResult" />
                 </Param>
-                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
-                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
-                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
+                <Param name="senderPipeName" sessionKey="PostZgwZaaknummer_reserverenResult" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="PostZgwZaaknummer_reserverenResult" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="PostZgwZaaknummer_reserverenResult" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
@@ -74,16 +74,17 @@
                     <Param name="Authorization"  sessionKey="Authorization" />
                 </HttpSender>
                 <Forward name="success" path="EXIT"/>
-                <Forward name="exception" path="ErrorJsonToXml" />
+                <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
-            <JsonPipe name="ErrorJsonToXml">
-                <Forward name="success" path="buildErrorMsg" />
-            </JsonPipe>
-            <XsltPipe name="buildErrorMsg"
-                styleSheetName="Common/xsl/ParseNegativeHttpResult.xsl">
+
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="senderPipeName" value="UpdateZgwZaak" />
+                <Forward name="success" path="ErrorJsonToXml" />
+            </DataSonnetPipe>
+            
+            <JsonPipe name="ErrorJsonToXml" rootElementName="error" storeResultInSessionKey="Error" >
                 <Forward name="success" path="EXCEPTION" />
-            </XsltPipe>
+            </JsonPipe>
         </Pipeline>
     </Adapter>
 </Module>

--- a/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
@@ -77,7 +77,7 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
-            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+            <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="UpdateZgwZaak" />
                 <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >

--- a/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
@@ -78,6 +78,7 @@
 			</SenderPipe>
 
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
+                <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="UpdateZgwZaak" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>

--- a/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
@@ -43,7 +43,7 @@
             <SenderPipe
                 name="UpdateZgwZaak"
                 getInputFromSessionKey="originalMessage"
-                >
+                storeResultInSessionKey="response">
                 <Json2XmlInputValidator
                     name="ValidatePatch"
                     schema="Zgw/Zaken/Model/PostZgwZaak.xsd"
@@ -80,6 +80,9 @@
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
                 <Param name="senderPipeName" value="UpdateZgwZaak" />
+                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                    <Param name="response" sessionKey="response" />
+                </Param>
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
@@ -77,12 +77,15 @@
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
 
+            <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">
                 <Param name="url" sessionKey="Url"/>
-                <Param name="senderPipeName" value="UpdateZgwZaak" />
-                <Param name="CDATA" value="&lt;dummy/&gt;" xpathExpression="$response" >
+                <Param name="responsePlainText" value="&lt;dummy/&gt;" xpathExpression="$response">
                     <Param name="response" sessionKey="response" />
                 </Param>
+                <Param name="senderPipeName" sessionKey="response" contextKey="Pipeline.PreviousPipe" />
+                <Param name="httpStatus" sessionKey="response" contextKey="Http.StatusCode" defaultValue="0" />
+                <Param name="httpReasonPhrase" sessionKey="response" contextKey="Http.ReasonPhrase" />
                 <Forward name="success" path="ErrorJsonToXml" />
             </DataSonnetPipe>
             

--- a/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
+++ b/src/main/configurations/Translate/Configuration_Zaken_UpdateZgwZaak.xml
@@ -73,9 +73,26 @@
                     <Param name="Content-Crs"  value="EPSG:4326" />
                     <Param name="Authorization"  sessionKey="Authorization" />
                 </HttpSender>
-                <Forward name="success" path="EXIT"/>
+                <Forward name="success" path="ResponseTypeSwitch"/>
                 <Forward name="exception" path="ParseNegativeHttpResult" />
 			</SenderPipe>
+            
+            <SwitchPipe
+                name="ResponseTypeSwitch"
+                forwardNameSessionKey="responseType">
+                <Forward name="application/json" path="EXIT" />
+                <Forward name="application/xml" path="JsonResponseToXml" />
+                <Forward name="notFound" path="EXIT" />
+                <Forward name="empty" path="EXIT" />
+            </SwitchPipe>
+            
+            <!-- JSON response -->
+
+            <!-- XML response -->
+            <JsonPipe
+                name="JsonResponseToXml">
+                <Forward name="success" path="EXIT" />
+            </JsonPipe>
 
             <!-- Error response -->
             <DataSonnetPipe styleSheetName="Common/jsonnet/ParseNegativeHttpResult.jsonnet" name="ParseNegativeHttpResult" getInputFromFixedValue="{}" storeResultInSessionKey="Error">


### PR DESCRIPTION
changed XsltPipe to datasonnetpipes.

added the requested resource, uri + uniqueid, as a param in the detailsXML

added unlessSessionKey="responseType" and  unlessValue="application/json" To keep the default response xml. This instead of the the 'Accept' param to keep this reserved for httprequests 

This Pr closes the following issue #679